### PR TITLE
Fix install.sh aborting after first skill

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,7 @@ while IFS= read -r skill_file; do
     done
 
     echo "  ${installed_name} -> ${skill_file}"
-    ((count++))
+    count=$((count + 1))
 
 done < <(find "${SKILLS_SRC}" -name "SKILL.md" -not -path "*/_template/*" | sort)
 


### PR DESCRIPTION
## Summary
- Fix `((count++))` with `set -e` causing install.sh to exit after installing only 1 of 60 skills
- Post-increment evaluates to 0 (falsy) on first iteration → exit code 1 → `set -e` aborts
- Replace with `count=$((count + 1))` which doesn't have this problem

## Test plan
- [ ] Run `./install.sh` and verify all 60 skills install
- [ ] Run `./install.sh --copy` and verify copy mode works
- [ ] Run `./uninstall.sh` and verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)