### PR TITLE
Enforce skill routing over inline execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Mode is set by the user or the orchestrator and propagated via conversation cont
 ### Inter-Skill Routing
 Skills route to each other using bold skill names in their escalation sections (e.g., "Route to **sql-injection-blind**"). Claude's skill matching picks up the context. When routing, pass: injection point, target technology, current mode, and any payloads that already succeeded.
 
+**Mandatory skill invocation**: When a skill says "Route to **skill-name**", you MUST invoke that skill using the Skill tool. Never execute a technique inline when a matching skill exists — even if you already know the technique. Skills contain methodology, edge cases, payloads, and troubleshooting that general knowledge does not. This applies in both guided and autonomous modes.
+
 ### Engagement Logging
 
 Skills support optional engagement logging for structured pentests.

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -22,6 +22,19 @@ vulnerabilities, chain them for maximum impact, and route to the correct
 technique skills for exploitation. All testing is under explicit written
 authorization.
 
+## Skill Routing Is Mandatory
+
+When this skill says "Route to **skill-name**", you MUST invoke the named
+skill using the Skill tool. Do NOT execute techniques inline — even if the
+attack path seems obvious or you already know the technique. Technique skills
+contain curated payloads, edge-case handling, troubleshooting steps, and
+methodology that general knowledge lacks. Skipping skill invocation trades
+thoroughness for speed and risks missing things on harder targets.
+
+This applies in both guided and autonomous modes. Autonomous mode means you
+make triage and routing decisions without asking — it does not mean you bypass
+the skill library.
+
 ## Mode
 
 Check if the user has set a mode:


### PR DESCRIPTION
## Summary
- During a live CTF (HackTheBox Bounty), the orchestrator bypassed technique skills and executed file upload bypass + JuicyPotato privesc inline from general knowledge
- This worked on a simple box but trades thoroughness for speed — technique skills contain curated payloads, edge-case handling, and troubleshooting that general knowledge lacks
- Added mandatory skill invocation directives to both `CLAUDE.md` (global inter-skill routing rule) and `skills/orchestrator/SKILL.md` (orchestrator-specific mandate)

## Test plan
- [ ] Run a new engagement and verify the orchestrator invokes technique skills via the Skill tool instead of going inline
- [ ] Confirm autonomous mode still routes without prompting but uses skill invocations
- [ ] Verify guided mode behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)