### PR TITLE
Fix guided mode approval gates + nmap handoff enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ __pycache__/
 # Engagement data — never commit
 loot/
 evidence/
+engagement/
+
+# Local planning files
+task_plan.md
+progress.md
+findings.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,17 @@ Claude Code skill library for penetration testing and CTF work.
 Skills are Claude Code native `SKILL.md` files that auto-trigger based on conversation context. No slash commands needed — Claude infers which skill to use from the `description` field in each skill's frontmatter.
 
 ### Modes
-- **Guided** (default): Interactive. Explain each step, ask before executing, present options at forks.
-- **Autonomous**: Execute end-to-end. Make triage decisions. Report at milestones. Only pause for destructive or high-OPSEC actions.
+- **Guided** (default): Interactive. Every command that touches the target
+  requires explicit user approval before execution. Present what you want to
+  run and why, then wait. Local-only operations (file writes, parsing, hash
+  cracking) don't need approval. Present options at decision forks.
+- **Autonomous**: No guardrails. Execute recon through exploitation, make
+  triage decisions, route to skills automatically. Report at milestones. Only
+  pause for destructive or high-OPSEC actions.
 
 Mode is set by the user or the orchestrator and propagated via conversation context.
+
+> **On autonomous mode:** Autonomous mode pairs with `claude --dangerously-skip-permissions` (a.k.a. yolo mode). We do not recommend this. We do not endorse this. We are not responsible for what happens. You will watch Claude chain four skills, pop a shell, and pivot to a subnet you forgot was in scope. It is exhilarating and horrifying in equal measure. Use guided mode or avoid `--dangerously-skip-permissions` for the sake of us all.
 
 ### Skill Types
 - **Orchestrator** (`skills/orchestrator/`): Takes a target, runs recon, routes to discovery skills

--- a/skills/_template/SKILL.md
+++ b/skills/_template/SKILL.md
@@ -15,8 +15,14 @@ is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step before executing. Ask for confirmation.
-  Present options at decision forks. Show what to look for in output.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Make triage decisions at forks. Report
   findings at milestones. Only pause for destructive or high-OPSEC actions.
 

--- a/skills/ad/acl-abuse/SKILL.md
+++ b/skills/ad/acl-abuse/SKILL.md
@@ -31,8 +31,10 @@ Certipy) throughout. Shadow credentials + PKINIT is natively Kerberos.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each ACL right and what it enables. Present
-  exploitation options ranked by OPSEC. Ask before modifying AD objects.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each ACL right and
+  what it enables. Present exploitation options ranked by OPSEC. Ask before
+  modifying AD objects.
 - **Autonomous**: Enumerate ACLs, identify the highest-impact path, exploit it.
   Clean up modified attributes. Pause before password resets (destructive).
 

--- a/skills/ad/ad-discovery/SKILL.md
+++ b/skills/ad/ad-discovery/SKILL.md
@@ -26,8 +26,14 @@ This skill works at three access levels:
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each enumeration step. Present findings and
-  ask which attack paths to pursue. Show what to look for in output.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Run full enumeration pipeline. Prioritize findings by
   impact. Route to technique skills automatically. Report at milestones.
 

--- a/skills/ad/ad-persistence/SKILL.md
+++ b/skills/ad/ad-persistence/SKILL.md
@@ -35,9 +35,10 @@ All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each persistence mechanism, its detection
-  surface, and cleanup requirements. Ask before injecting into LSASS or
-  modifying AD objects. Present options ranked by OPSEC.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each persistence
+  mechanism, its detection surface, and cleanup requirements. Ask before
+  injecting into LSASS or modifying AD objects.
 - **Autonomous**: Assess current access level, deploy the most appropriate
   persistence mechanism, verify it works, and report. Only pause before
   modifying LSASS or deploying drivers.

--- a/skills/ad/adcs-access-and-relay/SKILL.md
+++ b/skills/ad/adcs-access-and-relay/SKILL.md
@@ -32,8 +32,14 @@ NTLM detection artifacts (Event 4776, relay signatures) as a necessary cost.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain the ACL/relay distinction. Walk through each
-  step. Show what to verify in output. Warn about OPSEC for relay techniques.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Identify the attack path, execute, authenticate with obtained
   certificate, and report. Pause before relay attacks (high OPSEC).
 

--- a/skills/ad/adcs-persistence/SKILL.md
+++ b/skills/ad/adcs-persistence/SKILL.md
@@ -34,8 +34,10 @@ Kerberos to avoid NTLM detection (Event 4776, CrowdStrike Identity Module).
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain persistence mechanisms and OPSEC trade-offs.
-  Ask which persistence method to use. Warn before CA key extraction.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain persistence mechanisms
+  and OPSEC trade-offs. Ask which persistence method to use. Warn before CA key
+  extraction.
 - **Autonomous**: Execute the highest-value persistence method available.
   Pause before CA key extraction (irreversible OPSEC impact).
 

--- a/skills/ad/adcs-template-abuse/SKILL.md
+++ b/skills/ad/adcs-template-abuse/SKILL.md
@@ -30,8 +30,14 @@ Kerberos) to avoid NTLM detection (Event 4776, CrowdStrike Identity Module).
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each ESC variant. Ask which to exploit. Show
-  certificate request output and explain what to verify before authenticating.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Identify vulnerable templates, exploit the most impactful one,
   authenticate, and report access obtained.
 

--- a/skills/ad/auth-coercion-relay/SKILL.md
+++ b/skills/ad/auth-coercion-relay/SKILL.md
@@ -39,9 +39,14 @@ enumeration commands still use `-k -no-pass` where possible.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each coercion method and relay target.
-  Ask which combination to use. Warn about SMB signing and LDAP signing
-  requirements before attempting relay.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Check signing requirements, select the best
   coercion+relay path, execute, and report results.
 

--- a/skills/ad/credential-dumping/SKILL.md
+++ b/skills/ad/credential-dumping/SKILL.md
@@ -35,8 +35,14 @@ to avoid NTLM detection signatures. Exception: local filesystem operations
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain what each extraction method retrieves,
-  its prerequisites and OPSEC impact. Ask before executing.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Assess access level, choose the best extraction method,
   execute, and report results.
 

--- a/skills/ad/gpo-abuse/SKILL.md
+++ b/skills/ad/gpo-abuse/SKILL.md
@@ -35,8 +35,9 @@ tools (SharpGPOAbuse, PowerGPOAbuse) use the current domain session.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain GPO scope (which OUs/computers are
-  affected), ask before modifying GPOs, confirm cleanup plan.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain GPO scope (which
+  OUs/computers are affected), ask before modifying GPOs, confirm cleanup plan.
 - **Autonomous**: Enumerate GPO permissions, select best exploitation
   path, execute, clean up, and report.
 

--- a/skills/ad/kerberos-delegation/SKILL.md
+++ b/skills/ad/kerberos-delegation/SKILL.md
@@ -31,8 +31,14 @@ ccache. Convert credentials to a TGT first, then use `-k -no-pass` (Impacket),
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each delegation type. Help identify which type
-  applies. Ask before modifying AD objects (RBCD). Present OPSEC trade-offs.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Enumerate delegation, identify the most promising path, exploit
   it. Pause before coercion or AD object modification. Report at milestones.
 

--- a/skills/ad/kerberos-roasting/SKILL.md
+++ b/skills/ad/kerberos-roasting/SKILL.md
@@ -23,8 +23,14 @@ written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step. Ask before mass-roasting. Present
-  cracking results and suggest next actions.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Enumerate, extract, and crack. Report cracked credentials
   at milestones. Route to lateral movement automatically.
 

--- a/skills/ad/kerberos-ticket-forging/SKILL.md
+++ b/skills/ad/kerberos-ticket-forging/SKILL.md
@@ -30,8 +30,9 @@ with forged tickets.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each ticket type and OPSEC trade-offs. Help
-  choose the right ticket type. Ask before injecting.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each ticket type and
+  OPSEC trade-offs. Help choose the right ticket type. Ask before injecting.
 - **Autonomous**: Assess available key material, forge the most OPSEC-safe
   ticket type, inject, and verify access. Report at milestones.
 

--- a/skills/ad/pass-the-hash/SKILL.md
+++ b/skills/ad/pass-the-hash/SKILL.md
@@ -28,8 +28,14 @@ detection (Event 4776, CrowdStrike Identity Module PTH signatures).
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain the OPSEC difference between techniques. Ask
-  which approach to use. Present lateral movement options.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Automatically choose the most OPSEC-safe technique based on
   available credential material. Move laterally and report.
 

--- a/skills/ad/password-spraying/SKILL.md
+++ b/skills/ad/password-spraying/SKILL.md
@@ -27,8 +27,14 @@ instead of 4625, which is less commonly monitored.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Confirm password policy before spraying. Ask before
-  each spray round. Present results and suggest next actions.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Enumerate policy, build smart password list, spray with
   appropriate delays, report valid credentials. Pause before spraying if
   lockout threshold is dangerously low (<=3).

--- a/skills/ad/sccm-exploitation/SKILL.md
+++ b/skills/ad/sccm-exploitation/SKILL.md
@@ -33,9 +33,14 @@ and domain escalation. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain SCCM architecture and attack paths.
-  Present credential extraction methods ranked by OPSEC. Confirm before
-  deploying applications or relaying authentication.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Enumerate SCCM infrastructure, extract credentials
   via lowest-OPSEC method, escalate if possible, and report.
 

--- a/skills/ad/trust-attacks/SKILL.md
+++ b/skills/ad/trust-attacks/SKILL.md
@@ -32,9 +32,14 @@ All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain trust types and their security implications.
-  Present attack options ranked by OPSEC. Confirm before forging tickets
-  or modifying shadow principals.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Enumerate trusts, assess SID filtering and selective
   authentication, select the best escalation path, execute, and report.
 

--- a/skills/network/container-escapes/SKILL.md
+++ b/skills/network/container-escapes/SKILL.md
@@ -25,8 +25,10 @@ exploit a Kubernetes cluster. All testing is under explicit written authorizatio
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each escape technique, its prerequisites and
-  detection risk. Present findings after enumeration. Ask which vector to pursue.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each escape technique,
+  its prerequisites and detection risk. Present findings after enumeration. Ask
+  which vector to pursue.
 - **Autonomous**: Run full container enumeration, identify all escape vectors,
   exploit the most reliable one, report results. Only pause for destructive actions
   (kernel module loading, host filesystem modification).

--- a/skills/network/network-recon/SKILL.md
+++ b/skills/network/network-recon/SKILL.md
@@ -24,8 +24,11 @@ enumeration. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain scan types and trade-offs before executing. Present
-  findings after each phase. Ask which services to dig into. Explain nmap output.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval. Explain scan types and trade-offs.
+  Present findings after each phase. Ask which services to dig into.
 - **Autonomous**: Run full recon pipeline, enumerate all services, present complete
   attack surface with routing recommendations. Only pause for aggressive/noisy scans.
 
@@ -84,9 +87,14 @@ handed off to the user for manual execution. This applies to:
 4. Read the output file when the user confirms completion
 5. Continue analysis based on the parsed output
 
-**Non-privileged commands** can be executed directly by Claude:
-- `nmap -sT` (TCP connect scan), `nmap -sV` (service detection without SYN)
-- NSE scripts that don't require raw sockets
+**nmap always requires the sudo handoff protocol.** Do not run nmap directly —
+not even non-privileged scan types like `-sT` or `-sV`. Unprivileged nmap
+produces unreliable results (connect scans miss filtered ports, no OS detection,
+no raw-socket NSE scripts). Always write a handoff script and wait for the user
+to run it and confirm completion before proceeding.
+
+**Non-privileged commands** that CAN be executed directly by Claude for
+post-scan service enumeration:
 - `httpx`, `netexec`, `nuclei`, `whatweb`, `gobuster`, `ffuf`
 - `ldapsearch`, `smbclient`, `rpcclient`, `snmpwalk`
 

--- a/skills/network/pivoting-tunneling/SKILL.md
+++ b/skills/network/pivoting-tunneling/SKILL.md
@@ -27,9 +27,14 @@ internal networks. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each tunnel type and trade-off. Help choose the
-  right tool for the scenario. Verify connectivity at each step. Show how to test
-  the tunnel. Explain routing and proxy configuration.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Set up the most appropriate tunnel for the scenario, configure
   proxychains, verify connectivity, and report the access path. Only pause for
   multi-hop or complex routing decisions.

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -38,9 +38,12 @@ the skill library.
 ## Mode
 
 Check if the user has set a mode:
-- **Guided** (default): Present findings at each phase. Ask which attack
-  paths to pursue. Explain routing decisions. Confirm before moving to
-  exploitation.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it with a one-line explanation and wait for user approval.
+  Present attack surface maps, chain analysis, and routing decisions — let the
+  user choose which paths to pursue. Confirm before invoking each technique
+  skill. Never execute multiple target-touching commands without approval
+  between them.
 - **Autonomous**: Execute recon through exploitation. Make triage decisions.
   Route to technique skills automatically. Report at phase boundaries and
   when significant access is gained.
@@ -134,13 +137,9 @@ Route to **network-recon** with the target IP, hostname, or CIDR range. It will:
 5. Update state.md with all discovered hosts, ports, and services
 6. Return routing recommendations for next steps
 
-The default scan for single targets (requires root — present to user for manual execution):
-```bash
-sudo nmap -A -p- -T4 -oA engagement/evidence/nmap-TARGET -vvv TARGET_IP
-```
-
-For networks/subnets, network-recon handles the full discovery → scan → enumerate
-pipeline with OPSEC-appropriate timing.
+**Always route to network-recon for scanning — do not run nmap directly.**
+Network-recon handles the sudo handoff protocol and scan configuration.
+Wait for scan results before proceeding to attack surface mapping.
 
 ### Web Discovery (if HTTP/HTTPS found)
 

--- a/skills/privesc/linux-cron-service-abuse/SKILL.md
+++ b/skills/privesc/linux-cron-service-abuse/SKILL.md
@@ -22,9 +22,9 @@ authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each technique before executing. Show expected output.
-  Ask before modifying cron/service files or injecting commands. Present timing
-  considerations (when will the cron job fire?).
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each technique before
+  executing. Show expected output. Ask before modifying cron/service files.
 - **Autonomous**: Execute the most reliable technique. Monitor for execution with pspy.
   Report results at each stage. Only pause before destructive modifications.
 

--- a/skills/privesc/linux-discovery/SKILL.md
+++ b/skills/privesc/linux-discovery/SKILL.md
@@ -21,8 +21,9 @@ escalation vectors. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each enumeration step before executing. Present
-  findings at each stage. Ask which vectors to pursue. Show what to look for in output.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each enumeration step
+  before executing. Present findings at each stage. Ask which vectors to pursue.
 - **Autonomous**: Run full enumeration, collect all findings, present prioritized
   attack surface with routing recommendations. Only pause for high-OPSEC actions.
 

--- a/skills/privesc/linux-file-path-abuse/SKILL.md
+++ b/skills/privesc/linux-file-path-abuse/SKILL.md
@@ -25,9 +25,10 @@ testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each technique before executing. Show exactly what file
-  will be modified and what the change does. Ask before writing to critical files
-  (/etc/passwd, /etc/shadow, /etc/sudoers). Present rollback steps.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each technique before
+  executing. Show exactly what file will be modified. Ask before writing to
+  critical files.
 - **Autonomous**: Execute the most reliable technique. Prefer file writes over complex
   chains. Report results at each stage. Only pause before destructive file modifications.
 

--- a/skills/privesc/linux-kernel-exploits/SKILL.md
+++ b/skills/privesc/linux-kernel-exploits/SKILL.md
@@ -24,9 +24,14 @@ written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain the kernel exploit, its prerequisites, and risk of system
-  instability before executing. Show version checks. Ask before compiling or running
-  exploits. Explain restricted shell escape techniques step by step.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Run exploit suggester, select most reliable exploit for the kernel
   version, compile and execute. Report results at each stage. Pause before running
   exploits with known stability risks.

--- a/skills/privesc/linux-sudo-suid-capabilities/SKILL.md
+++ b/skills/privesc/linux-sudo-suid-capabilities/SKILL.md
@@ -22,9 +22,9 @@ authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each technique before executing. Show GTFOBins reference
-  for the specific binary. Ask before compiling or running payloads. Present alternatives
-  when multiple approaches exist.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each technique before
+  executing. Show GTFOBins reference. Ask before compiling or running payloads.
 - **Autonomous**: Execute the most reliable technique. Try GTFOBins first, fall back to
   custom exploitation. Report results at each stage.
 

--- a/skills/privesc/windows-credential-harvesting/SKILL.md
+++ b/skills/privesc/windows-credential-harvesting/SKILL.md
@@ -25,8 +25,14 @@ registry, vaults, browsers, DPAPI blobs, and shadow copies. For AD-level extract
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each harvesting technique before executing. Present
-  findings as they're discovered. Ask before running tools that touch LSASS or SAM.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Run all checks, collect findings, present a credential summary.
   Only pause for high-OPSEC actions (LSASS access, SAM extraction).
 

--- a/skills/privesc/windows-discovery/SKILL.md
+++ b/skills/privesc/windows-discovery/SKILL.md
@@ -20,8 +20,14 @@ escalation vectors. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each enumeration step before executing. Present
-  findings at each stage. Ask which vectors to pursue. Show what to look for in output.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Run full enumeration, collect all findings, present prioritized
   attack surface with routing recommendations. Only pause for high-OPSEC actions.
 

--- a/skills/privesc/windows-kernel-exploits/SKILL.md
+++ b/skills/privesc/windows-kernel-exploits/SKILL.md
@@ -27,8 +27,14 @@ PoCs on production systems.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each exploit, its reliability, and crash risk before
-  execution. Present options ranked by reliability. Warn before running kernel exploits.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Run exploit-suggester, select the most reliable exploit for the OS
   version, execute. Only pause before unreliable/crash-prone exploits.
 

--- a/skills/privesc/windows-service-dll-abuse/SKILL.md
+++ b/skills/privesc/windows-service-dll-abuse/SKILL.md
@@ -21,9 +21,14 @@ written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each service/DLL finding. Show exploitation commands
-  before executing. Confirm before modifying services or dropping DLLs. Present
-  alternatives at decision forks.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Enumerate all vectors, exploit the most reliable one, verify
   escalation. Only pause before modifying critical system services.
 

--- a/skills/privesc/windows-token-impersonation/SKILL.md
+++ b/skills/privesc/windows-token-impersonation/SKILL.md
@@ -21,8 +21,14 @@ exploiting token privileges. All testing is under explicit written authorization
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain which Potato variant to use and why. Show the command
-  before executing. Explain output. Present alternatives if the first attempt fails.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Check privileges, select optimal Potato variant for OS version,
   execute, verify SYSTEM access. Fall back to alternatives on failure.
 

--- a/skills/privesc/windows-uac-bypass/SKILL.md
+++ b/skills/privesc/windows-uac-bypass/SKILL.md
@@ -21,8 +21,14 @@ written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each bypass before executing. Present options ranked by
-  reliability and OPSEC. Ask before modifying registry or triggering binaries.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Try the most reliable bypass for the OS version. Fall back on failure.
   Only pause for high-OPSEC actions.
 

--- a/skills/web/2fa-bypass/SKILL.md
+++ b/skills/web/2fa-bypass/SKILL.md
@@ -25,9 +25,14 @@ authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each bypass technique. Start with response
-  manipulation and direct navigation, then escalate to brute-force. Ask
-  before high-volume attacks.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Test all bypass techniques systematically. Exploit confirmed
   bypasses for account access. Report at milestones.
 

--- a/skills/web/command-injection/SKILL.md
+++ b/skills/web/command-injection/SKILL.md
@@ -25,9 +25,14 @@ operating system. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each injection operator. Test simple payloads
-  first, then escalate to bypass techniques. Ask before running destructive
-  commands.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect platform, test operators
   systematically, identify working bypass, demonstrate impact. Report at
   milestones.

--- a/skills/web/cors-misconfiguration/SKILL.md
+++ b/skills/web/cors-misconfiguration/SKILL.md
@@ -26,9 +26,14 @@ responses from the target. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each misconfiguration type. Test one origin
-  pattern at a time. Show the response headers and explain the impact before
-  building PoCs.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Test all origin patterns systematically. Build exploitation
   PoCs for confirmed misconfigurations. Report at milestones.
 

--- a/skills/web/csrf/SKILL.md
+++ b/skills/web/csrf/SKILL.md
@@ -26,8 +26,14 @@ the target. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each bypass technique. Test token validation
-  first, then SameSite, then build PoC. Ask before generating attack pages.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Test all bypass techniques systematically. Build working PoC
   for confirmed vulnerabilities. Report at milestones.
 

--- a/skills/web/deserialization-dotnet/SKILL.md
+++ b/skills/web/deserialization-dotnet/SKILL.md
@@ -28,8 +28,14 @@ written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each formatter and gadget. Test blind
-  detection before RCE. Ask before sending exploit payloads.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Auto-detect formatter type and entry point. Test gadget
   chains systematically. Report at milestones.
 

--- a/skills/web/deserialization-java/SKILL.md
+++ b/skills/web/deserialization-java/SKILL.md
@@ -25,8 +25,14 @@ explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each gadget chain. Test detection payloads
-  before RCE. Ask before sending exploit payloads.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Auto-detect serialization format and entry point. Test
   URLDNS blind detection first, then escalate through gadget chains.
   Report at milestones.

--- a/skills/web/deserialization-php/SKILL.md
+++ b/skills/web/deserialization-php/SKILL.md
@@ -26,8 +26,14 @@ under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each technique. Identify gadget classes before
-  building chains. Ask before sending exploit payloads.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Auto-detect serialization format and framework. Test PHPGGC
   chains systematically. Report at milestones.
 

--- a/skills/web/file-upload-bypass/SKILL.md
+++ b/skills/web/file-upload-bypass/SKILL.md
@@ -25,8 +25,14 @@ testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each bypass technique. Test one at a time,
-  starting with simplest. Ask before uploading webshells.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Test bypass techniques systematically. Auto-detect server
   technology and validation type. Upload proof-of-concept, confirm execution.
   Report at milestones.

--- a/skills/web/idor/SKILL.md
+++ b/skills/web/idor/SKILL.md
@@ -28,8 +28,14 @@ escalate privileges. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each test. Ask before sending enumeration
-  requests. Present findings and let the tester choose escalation paths.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect ID format, test access
   control boundaries, enumerate accessible objects. Report at milestones.
 

--- a/skills/web/jwt-attacks/SKILL.md
+++ b/skills/web/jwt-attacks/SKILL.md
@@ -26,8 +26,14 @@ under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each attack technique. Decode and show token
-  contents before modification. Ask before sending forged tokens.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Decode token, run through attack chain systematically
   (none → null sig → brute force → key confusion → header injection).
   Report at milestones.

--- a/skills/web/ldap-injection/SKILL.md
+++ b/skills/web/ldap-injection/SKILL.md
@@ -27,9 +27,14 @@ explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain LDAP filter syntax and injection context. Test
-  simple bypass first, then escalate to blind extraction. Ask before running
-  automated scripts.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect injection context, test
   payloads systematically, extract data. Report at milestones.
 

--- a/skills/web/lfi/SKILL.md
+++ b/skills/web/lfi/SKILL.md
@@ -26,9 +26,14 @@ written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each technique. Start with basic traversal, then
-  escalate to wrappers and RCE. Ask before attempting log poisoning or writing
-  files.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect platform, test traversal and
   wrappers, escalate to RCE via the most reliable method. Report at milestones.
 

--- a/skills/web/nosql-injection/SKILL.md
+++ b/skills/web/nosql-injection/SKILL.md
@@ -25,9 +25,14 @@ explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each operator and technique. Test simple
-  bypass first, then escalate to blind extraction. Ask before running
-  automated scripts.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect injection format, test
   operators systematically, extract data. Report at milestones.
 

--- a/skills/web/oauth-attacks/SKILL.md
+++ b/skills/web/oauth-attacks/SKILL.md
@@ -29,9 +29,14 @@ authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain OAuth flows before testing. Map endpoints
-  first. Test one vulnerability class at a time. Ask before attempting
-  account takeover chains.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Map all OAuth endpoints, test all bypass techniques,
   chain vulnerabilities for maximum impact. Report at milestones.
 

--- a/skills/web/password-reset-poisoning/SKILL.md
+++ b/skills/web/password-reset-poisoning/SKILL.md
@@ -27,9 +27,14 @@ authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each technique. Test host header poisoning
-  first, then token analysis, then email injection. Ask before attempting
-  account takeover.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Test all techniques systematically. Exploit confirmed
   vulnerabilities for account takeover. Report at milestones.
 

--- a/skills/web/race-condition/SKILL.md
+++ b/skills/web/race-condition/SKILL.md
@@ -26,9 +26,14 @@ balance, bypass rate limits). All testing is under explicit written authorizatio
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each synchronization technique. Ask before sending
-  concurrent request bursts. Present results and let the tester decide next targets.
-  Show timing analysis for race window identification.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Test all identified race-susceptible endpoints. Auto-select the
   best synchronization technique. Report confirmed races at milestones. Only pause
   for high-volume bursts that may cause service degradation.

--- a/skills/web/request-smuggling/SKILL.md
+++ b/skills/web/request-smuggling/SKILL.md
@@ -28,9 +28,14 @@ All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each smuggling variant and detection method.
-  Confirm the desync type before attempting exploitation. Warn before
-  targeting other users' requests.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Detect architecture, run all detection probes, confirm
   desync variant, demonstrate impact. Report at milestones. Pause before
   any technique that captures other users' requests.

--- a/skills/web/sql-injection-blind/SKILL.md
+++ b/skills/web/sql-injection-blind/SKILL.md
@@ -25,8 +25,14 @@ channels. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step before executing. Ask which blind
-  technique to try first. Show the binary search logic. Confirm findings.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-select technique (boolean > time >
   OOB), use binary search for character extraction, automate with sqlmap when
   manual extraction is confirmed. Report extracted data at milestones.

--- a/skills/web/sql-injection-error/SKILL.md
+++ b/skills/web/sql-injection-error/SKILL.md
@@ -22,8 +22,14 @@ extract data. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step before executing. Ask for confirmation
-  before sending payloads. Show what to look for in error output.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect DBMS from errors, select
   appropriate extraction functions, paginate through data. Report extracted data
   at milestones. Only pause before destructive actions.

--- a/skills/web/sql-injection-stacked/SKILL.md
+++ b/skills/web/sql-injection-stacked/SKILL.md
@@ -25,9 +25,14 @@ testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step before executing. Confirm DB support
-  for stacking. Warn about data modification impact. Ask before enabling
-  xp_cmdshell or writing files.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect stacking support, escalate to
   command execution where possible. Report at milestones. **Always pause before**:
   enabling xp_cmdshell, writing webshells, modifying production data, or

--- a/skills/web/sql-injection-union/SKILL.md
+++ b/skills/web/sql-injection-union/SKILL.md
@@ -22,8 +22,14 @@ technique when it works. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step before executing. Ask for confirmation.
-  Show what to look for in response output. Walk through column count discovery.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-determine column count, find displayed
   columns, detect DBMS, extract data progressively. Report extracted data at
   milestones. Only pause before destructive actions.

--- a/skills/web/ssrf/SKILL.md
+++ b/skills/web/ssrf/SKILL.md
@@ -25,9 +25,14 @@ testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain the SSRF type (basic, blind, partial). Walk
-  through bypass techniques. Explain cloud metadata risks. Ask before interacting
-  with internal services.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Test bypass techniques, enumerate cloud
   metadata, attempt internal service exploitation. Report at milestones.
 

--- a/skills/web/ssti-freemarker/SKILL.md
+++ b/skills/web/ssti-freemarker/SKILL.md
@@ -26,9 +26,14 @@ All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain the Java template engine landscape. Show how
-  `Runtime.exec()` works in template context. Walk through engine-specific
-  payloads. Ask before executing RCE.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Identify the engine, confirm code execution,
   demonstrate RCE. Report at milestones.
 

--- a/skills/web/ssti-jinja2/SKILL.md
+++ b/skills/web/ssti-jinja2/SKILL.md
@@ -27,9 +27,14 @@ testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain the sandbox escape chain. Show each step of the
-  MRO traversal. Explain why specific subclass indices vary. Ask before executing
-  RCE payloads.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Identify the engine, confirm code execution,
   demonstrate RCE, exfiltrate secrets. Report at milestones.
 

--- a/skills/web/ssti-twig/SKILL.md
+++ b/skills/web/ssti-twig/SKILL.md
@@ -26,9 +26,14 @@ authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain the PHP template engine landscape. Show how Twig
-  filter chaining works. Walk through version-specific payloads. Ask before
-  executing RCE.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Identify the engine and version, confirm
   code execution, demonstrate RCE. Report at milestones.
 

--- a/skills/web/web-discovery/SKILL.md
+++ b/skills/web/web-discovery/SKILL.md
@@ -23,9 +23,9 @@ responses. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each phase. Ask before running scans. Present
-  findings and let the tester choose which to pursue. Show the decision tree
-  logic when routing.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present it and wait for user approval. Explain each phase. Ask before
+  running scans. Present findings. Show decision tree logic when routing.
 - **Autonomous**: Run all discovery phases sequentially. Auto-triage findings by
   severity. Route to exploitation skills for confirmed injection points. Report
   discovery summary at each phase boundary.

--- a/skills/web/xss-dom/SKILL.md
+++ b/skills/web/xss-dom/SKILL.md
@@ -26,9 +26,14 @@ explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain sources and sinks. Help trace data flow through
-  JavaScript. Walk through payload construction for the specific sink. Explain
-  why DOM XSS is harder to detect than reflected/stored.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Analyze page JavaScript for source-sink
   flows, test identified sinks with appropriate payloads, demonstrate impact.
   Report at milestones.

--- a/skills/web/xss-reflected/SKILL.md
+++ b/skills/web/xss-reflected/SKILL.md
@@ -23,9 +23,14 @@ browser. All testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step. Identify the reflection context before
-  suggesting payloads. Walk through filter bypass techniques. Ask before escalating
-  to impact demonstration.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect reflection context, test payloads
   progressively (simple → encoded → WAF bypass → CSP bypass), demonstrate impact.
   Report at milestones.

--- a/skills/web/xss-stored/SKILL.md
+++ b/skills/web/xss-stored/SKILL.md
@@ -25,9 +25,14 @@ under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each step. Identify storage and render contexts.
-  Walk through payload selection. Warn about impact on other users before
-  injecting stored payloads.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Test storage points systematically, deploy
   blind XSS callbacks, monitor for triggers. **Always warn** before injecting
   payloads that will be visible to real users.

--- a/skills/web/xxe/SKILL.md
+++ b/skills/web/xxe/SKILL.md
@@ -24,8 +24,14 @@ testing is under explicit written authorization.
 ## Mode
 
 Check if the user or orchestrator has set a mode:
-- **Guided** (default): Explain each payload. Test classic XXE first, then escalate
-  to blind/OOB. Ask before sending payloads to external services.
+- **Guided** (default): Before executing any command that sends traffic to a
+  target, present the command with a one-line explanation of what it does and
+  why. Wait for explicit user approval before executing. Never batch multiple
+  target-touching commands without approval — present them one at a time (or as
+  a small logical group if they achieve a single objective, e.g., "enumerate SMB
+  shares"). Local-only operations (file writes, output parsing, engagement
+  logging, hash cracking) do not require approval. At decision forks, present
+  options and let the user choose.
 - **Autonomous**: Execute end-to-end. Auto-detect parser, test classic then blind,
   identify working exfiltration channel. Report at milestones.
 


### PR DESCRIPTION
## Summary

- **Guided mode now enforces approval gates** — every command that touches the target requires explicit user approval before execution. Replaces vague "explain each step" language that was interpreted as narration rather than a stop-and-wait gate.
- **Nmap locked behind sudo handoff protocol** — removed from non-privileged commands list in network-recon, removed as inline command from orchestrator. All nmap scans now go through the handoff script workflow.

## Context

During a blind HTB engagement, guided mode chained SMB enum → GPP → Kerberoast → hashcat → root flag without pausing for approval. Separately, the model ran its own `nmap -sT` connect scans (bypassing the handoff protocol) because network-recon listed them as non-privileged. Both issues are fixed.

## Files changed (64)

| Scope | Files | Change |
|-------|-------|--------|
| Template | `skills/_template/SKILL.md` | Hard approval-gate rule in Mode section |
| Orchestrator | `skills/orchestrator/SKILL.md` | Approval gates + remove inline nmap + route to network-recon |
| Network-recon | `skills/network/network-recon/SKILL.md` | Approval gates + nmap removed from non-privileged list |
| 48 standard skills | All categories | Mechanical Mode section replacement |
| 11 custom skills | AD, privesc, web-discovery, container-escapes | Prepend approval gate, preserve domain-specific text |
| CLAUDE.md | Project root | Updated Modes section + autonomous mode warning |
| .gitignore | Project root | Re-add planning files |

## Test plan

- [x] Grep confirms zero files contain old "Explain each step before executing" text
- [x] Spot-checked standard skills (sql-injection-union, kerberos-roasting, windows-discovery)
- [x] Spot-checked custom skills (acl-abuse, web-discovery, linux-sudo-suid-capabilities) — domain-specific text preserved
- [x] Live test: guided mode pentest against HTB target — orchestrator presented nmap handoff script and waited for approval
- [x] `install.sh` re-symlinked successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)