### PR TITLE
Document sandbox network command workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,14 @@ description: >
 - **Discovery skill maintenance**: When creating a new technique skill, update the corresponding discovery skill's routing table to include it. `web-discovery` must route to every web technique skill.
 - **AD OPSEC: Kerberos-first authentication**: All AD skills default to Kerberos authentication via ccache to avoid NTLM-specific detections (Event 4776, CrowdStrike Identity Module PTH signatures). Each AD skill's Prerequisites section includes the `getTGT.py` → `KRB5CCNAME` → `-k -no-pass` workflow. All embedded tool commands use Kerberos auth flags: Impacket (`-k -no-pass`), NetExec (`--use-kcache`), Certipy (`-k`), bloodyAD (`-k`). Skills where Kerberos auth doesn't apply (relay, coercion, password spraying) explicitly state why and note the NTLM detection surface.
 
+## Sandbox & Network Commands
+
+Claude Code's bwrap sandbox blocks network socket creation. Since pentesting skills are almost entirely network commands, this causes every tool (`nmap`, `netexec`, `sqlmap`, etc.) to fail on first attempt, then retry with sandbox disabled — doubling execution time.
+
+**Fix:** Add a network tools exception to your global `~/.claude/CLAUDE.md` that tells Claude to proactively use `dangerouslyDisableSandbox: true` for network-touching commands. See the sandbox section in the [global CLAUDE.md template](https://github.com/kevinoriley/claude-config) for the full list.
+
+Local-only commands (file I/O, hash cracking, parsing) should keep sandbox enabled.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- Added "Sandbox & Network Commands" section to project CLAUDE.md explaining that bwrap blocks socket creation and how to fix it
- Corresponding global `~/.claude/CLAUDE.md` change (not in this repo) adds a network tools exception list so Claude proactively disables sandbox for network commands instead of failing first

## Test plan
- [ ] Verify network commands (nmap, netexec, curl) run without fail-then-retry during next engagement

🤖 Generated with [Claude Code](https://claude.com/claude-code)