### PR TITLE
Move sandbox docs to README, cross-reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,13 +134,9 @@ description: >
 - **Discovery skill maintenance**: When creating a new technique skill, update the corresponding discovery skill's routing table to include it. `web-discovery` must route to every web technique skill.
 - **AD OPSEC: Kerberos-first authentication**: All AD skills default to Kerberos authentication via ccache to avoid NTLM-specific detections (Event 4776, CrowdStrike Identity Module PTH signatures). Each AD skill's Prerequisites section includes the `getTGT.py` → `KRB5CCNAME` → `-k -no-pass` workflow. All embedded tool commands use Kerberos auth flags: Impacket (`-k -no-pass`), NetExec (`--use-kcache`), Certipy (`-k`), bloodyAD (`-k`). Skills where Kerberos auth doesn't apply (relay, coercion, password spraying) explicitly state why and note the NTLM detection surface.
 
-## Sandbox & Network Commands
+## Sandbox
 
-Claude Code's bwrap sandbox blocks network socket creation. Since pentesting skills are almost entirely network commands, this causes every tool (`nmap`, `netexec`, `sqlmap`, etc.) to fail on first attempt, then retry with sandbox disabled — doubling execution time.
-
-**Fix:** Add a network tools exception to your global `~/.claude/CLAUDE.md` that tells Claude to proactively use `dangerouslyDisableSandbox: true` for network-touching commands. See the sandbox section in the [global CLAUDE.md template](https://github.com/kevinoriley/claude-config) for the full list.
-
-Local-only commands (file I/O, hash cracking, parsing) should keep sandbox enabled.
+The bwrap sandbox blocks network socket creation. Users must configure their global `~/.claude/CLAUDE.md` to disable sandbox for network tools — see README.md "Sandbox and network commands" for the setup.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,26 @@ Skills install to `~/.claude/skills/red-run-<skill-name>/SKILL.md`.
 
 Always run red-run from a VM or dedicated pentesting machine. Skills execute commands, transfer tools, and interact with targets — you want network isolation and a disposable environment. A purpose-built Linux VM with your pentesting tools and Claude Code installed is the intended setup.
 
+### Sandbox and network commands
+
+Claude Code's bwrap sandbox blocks network socket creation. Since pentesting skills are almost entirely network commands, every tool (`nmap`, `netexec`, `sqlmap`, etc.) will fail on first attempt, then retry with sandbox disabled — doubling execution time.
+
+**Fix:** Add a network tools exception to your global `~/.claude/CLAUDE.md` that tells Claude to proactively use `dangerouslyDisableSandbox: true` for network-touching commands. Local-only commands (file I/O, hash cracking, parsing) should keep sandbox enabled. Example:
+
+```markdown
+## Sandbox
+
+Always use `dangerouslyDisableSandbox: true` for commands that make network
+connections: nmap, ping, netexec, curl, wget, sqlmap, impacket-*, certipy,
+bloodyAD, ffuf, nuclei, httpx, responder, tcpdump, ssh, smbclient, ldapsearch,
+crackmapexec, gobuster, hydra, chisel, ligolo, socat, nc, bbot, nikto, wfuzz,
+feroxbuster, enum4linux-ng, rpcclient, scp, rsync, proxychains,
+python3 -m http.server.
+
+For everything else (file reads, writes, local processing, hash cracking),
+keep sandbox enabled.
+```
+
 ### Recommended configuration
 
 This project was built with the [Trail of Bits Claude Code configuration](https://github.com/trailofbits/claude-code-config) in mind:


### PR DESCRIPTION
## Summary
- Moved "Sandbox & Network Commands" section from CLAUDE.md to README.md (user-facing setup docs belong in README)
- Added brief cross-reference in CLAUDE.md pointing to README
- README now includes the example `~/.claude/CLAUDE.md` config block

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)