### PR TITLE
Add retrospective loop to README and orchestrator post-engagement prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,23 @@ Large engagements generate more state than fits in a single conversation context
 
 Every skill reads `state.md` on activation and writes back on completion. The orchestrator uses `state.md` + Pivot Map to chain vulnerabilities toward maximum impact. Kept under ~200 lines — one-liner per item, current state not history.
 
+## The retrospective loop
+
+The skills in this repo are a starting point. The retrospective skill is what makes them yours.
+
+After an engagement, run a retrospective. Claude reads the engagement directory — `activity.md`, `state.md`, `findings.md` — and analyzes what happened. It reviews every skill routing decision, identifies gaps in payloads and methodology, flags techniques that were done by hand instead of through a skill, and produces a prioritized list of improvements: skill updates, new skills to build, routing fixes.
+
+The actionable items are specific. Not "improve the XXE skill" but "add a Custom Sudo Script Analysis section to `linux-sudo-suid-capabilities` covering eval/exec/os.system sinks in sudo-allowed scripts, with constraint-satisfaction methodology." You discuss the findings with Claude, decide what to change, and update the skills right there in the same session.
+
+This is where red-run starts to work differently for you than for anyone else. After a few engagements:
+
+- Your web skills carry the payloads that actually worked against the stacks you see most often
+- Your AD skills reflect the tools and authentication workflows you prefer
+- Your privesc skills cover the edge cases you've personally hit
+- Your discovery skills route to techniques in the order that matches your methodology
+
+The cycle is: **engage → retrospective → improve skills → engage again**. Each pass through the loop makes the library more effective for the specific types of targets, environments, and toolchains you work with. The skills become a living record of your methodology — refined by real engagements, not hypothetical coverage.
+
 ## Installation
 
 ### Install

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -457,6 +457,16 @@ objective completion>
 <Prioritized remediation guidance>
 ```
 
+### Retrospective
+
+After presenting the engagement summary, suggest running a retrospective:
+
+> Engagement complete. Want to run a retrospective? It reviews skill routing
+> decisions, identifies payload and methodology gaps, and produces actionable
+> improvements to make the skills work better for you next time.
+
+If the user agrees, invoke **retrospective** via the Skill tool.
+
 ## OPSEC Notes
 
 - Recon phase (nmap, httpx) is relatively low-OPSEC but generates network


### PR DESCRIPTION
## Summary
- **README**: New "The retrospective loop" section explaining how the retrospective skill creates a feedback loop that customizes skills to the operator's methodology over time
- **Orchestrator**: After presenting the engagement summary, suggest running a retrospective (always opt-in, regardless of mode)

## Test plan
- [x] Verified orchestrator suggests retrospective at end of BountyHunter.htb engagement
- [x] Verified retrospective skill reads engagement directory and produces actionable skill improvement items
- [x] Review README section reads well in rendered markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)