### PR TITLE
Enforce skill routing in multi-target engagements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Skills route to each other using bold skill names in their escalation sections (
 
 **Mandatory skill invocation**: When a skill says "Route to **skill-name**", you MUST invoke that skill using the Skill tool. Never execute a technique inline when a matching skill exists — even if you already know the technique. Skills contain methodology, edge cases, payloads, and troubleshooting that general knowledge does not. This applies in both guided and autonomous modes.
 
+**Task sub-agents cannot invoke skills.** The Skill tool is only available in the main conversation thread. Never delegate target-level work (scanning, exploitation, post-exploitation) to Task sub-agents — they bypass all skill routing, engagement logging, and state management. Use Task sub-agents only for local processing (hash cracking, output parsing, research). See the orchestrator's "Multi-Target Engagements" section for the correct approach to multiple targets.
+
 ### Engagement Logging
 
 Skills support optional engagement logging for structured pentests.


### PR DESCRIPTION
## Summary
- Adds explicit guidance forbidding Task sub-agent delegation for target-level work (scanning, exploitation, post-exploitation) — sub-agents can't invoke the Skill tool, so they bypass all skill routing
- Adds "Multi-Target Engagements" section (Step 7) with phase-based cycling strategy: recon all → triage → work highest-value → cross-pollinate → cycle back
- Requires interactive shell stabilization (webshell → reverse shell) before routing to host discovery skills — prevents fragile privesc enumeration through webshells

## Context
During a multi-target CTF engagement, the orchestrator spawned one Task sub-agent per target for parallelism. Each sub-agent executed techniques inline without skill routing, engagement logging, or state management. This produced two downstream failures:
1. XXE agent uploaded a webshell then attempted privesc enumeration through URL-encoded GET requests instead of establishing an interactive shell first
2. No engagement state was shared between targets — credentials found on one target were never tested against others

## Test plan
- [ ] Run orchestrator against 2+ targets in autonomous mode — verify it processes targets sequentially through skills, not via parallel sub-agents
- [ ] Verify webshell → reverse shell → discovery routing sequence on a target with XXE or file upload
- [ ] Verify cross-pollination: credentials from target A are tested against target B

🤖 Generated with [Claude Code](https://claude.com/claude-code)