### PR TITLE
Enforce skill routing in multi-target engagements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Skills route to each other using bold skill names in their escalation sections (
 
 **Mandatory skill invocation**: When a skill says "Route to **skill-name**", you MUST invoke that skill using the Skill tool. Never execute a technique inline when a matching skill exists — even if you already know the technique. Skills contain methodology, edge cases, payloads, and troubleshooting that general knowledge does not. This applies in both guided and autonomous modes.
 
+**Task sub-agents cannot invoke skills.** The Skill tool is only available in the main conversation thread. Never delegate target-level work (scanning, exploitation, post-exploitation) to Task sub-agents — they bypass all skill routing, engagement logging, and state management. Use Task sub-agents only for local processing (hash cracking, output parsing, research). See the orchestrator's "Multi-Target Engagements" section for the correct approach to multiple targets.
+
 ### Engagement Logging
 
 Skills support optional engagement logging for structured pentests.


### PR DESCRIPTION
## Summary

- Prevent orchestrator from delegating target-level work to Task sub-agents (sub-agents can't invoke skills, bypassing all routing/logging/state)
- Add phase-based cycling strategy for multi-target engagements that preserves skill routing
- Require interactive shell stabilization before routing to host discovery skills

## Changes

**Orchestrator (`skills/orchestrator/SKILL.md`):**
- New "Do Not Delegate Targets to Sub-Agents" section with explicit allowlist/denylist for Task tool usage
- New "Multi-Target Engagements" (Step 7) with phase-based cycling: recon all → triage → work highest-value → cross-pollinate → cycle back
- Shell access routing now requires stabilizing to an interactive shell before invoking discovery skills (webshell/blind RCE → reverse shell → discovery)
- State management guidance for tracking multiple targets in a single `state.md`

**CLAUDE.md:**
- Added Task sub-agent warning to Inter-Skill Routing section

## Context

The orchestrator's most dangerous failure mode is spawning one Task sub-agent per target — it looks efficient but produces methodology-free improvisation since sub-agents can't invoke skills. This PR makes that constraint explicit and provides the correct alternative.

## Test plan

- [ ] Verify orchestrator routes to skills sequentially when given multiple targets
- [ ] Verify Task sub-agents are only used for local processing (hash cracking, output parsing)
- [ ] Verify shell stabilization step occurs before discovery skill routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)