### PR TITLE
Add Clock Skew Interrupt pattern across AD skill library

### DIFF
--- a/agents/ad-agent.md
+++ b/agents/ad-agent.md
@@ -60,6 +60,25 @@ state.md for existing ccache files or TGTs before requesting new ones.
 (relay attacks, coercion, password spraying without creds). Follow the skill's
 guidance.
 
+## Clock Skew Interrupt
+
+If **any** Kerberos operation returns `KRB_AP_ERR_SKEW`, `Clock skew too great`,
+or `Kerberos SessionError: KRB_AP_ERR_SKEW`:
+
+**STOP IMMEDIATELY.** Do not retry. Do not fall back to NTLM. Do not continue
+with the skill methodology.
+
+1. Update `engagement/state.md` Blocked section:
+   `Clock skew: KRB_AP_ERR_SKEW — requires sudo ntpdate <DC_IP>`
+2. Return to the orchestrator with:
+   - Error: `KRB_AP_ERR_SKEW` (clock skew > 5 minutes)
+   - Fix: `sudo ntpdate <DC_IP>` (requires root — cannot execute from subagent)
+   - Assessment: **retry-later** (skill will work after clock sync)
+   - Include any findings gathered before the error
+
+This is not a stall — it is a known prerequisite failure requiring operator
+intervention. Do not spend rounds trying alternatives or workarounds.
+
 ## Reverse Shell via MCP
 
 You have access to the `shell-server` MCP tools for managing reverse shell

--- a/skills/ad/acl-abuse/SKILL.md
+++ b/skills/ad/acl-abuse/SKILL.md
@@ -622,6 +622,17 @@ If no CA exists, fall back to targeted Kerberoasting (Option B).
 - Verify `KRB5CCNAME` points to a valid ccache
 - Try `--host DC_FQDN` (not IP) for Kerberos name resolution
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ### OPSEC Comparison
 
 | Technique | OPSEC | Event IDs | Destructive |

--- a/skills/ad/ad-discovery/SKILL.md
+++ b/skills/ad/ad-discovery/SKILL.md
@@ -582,8 +582,9 @@ When routing to a technique skill, pass along:
 
 ### Kerberos Errors
 
-- **KRB_AP_ERR_SKEW**: Clock out of sync. Fix with `sudo ntpdate DC_IP` or
-  `sudo rdate -n DC_IP` (requires root — present to user for manual execution)
+- **KRB_AP_ERR_SKEW**: Clock out of sync (> 5 minutes from DC). This is a
+  **Clock Skew Interrupt** — stop immediately and return to the orchestrator.
+  Do not retry or fall back to NTLM. Fix requires root: `sudo ntpdate DC_IP`
 - **KDC cannot find the name**: Use FQDN hostnames, not IP addresses. Ensure
   DNS resolves to the DC or add entries to `/etc/hosts`
 

--- a/skills/ad/ad-persistence/SKILL.md
+++ b/skills/ad/ad-persistence/SKILL.md
@@ -652,6 +652,17 @@ Do not loop. Work through failures systematically:
 - **Log location**: kiwissp.log (mimilib) or mimilsa.log (memssp) in
   `C:\Windows\System32\`.
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ## OPSEC Comparison
 
 | Technique | OPSEC | Detection Indicators |

--- a/skills/ad/adcs-access-and-relay/SKILL.md
+++ b/skills/ad/adcs-access-and-relay/SKILL.md
@@ -561,6 +561,17 @@ CA may require restart for new officer permissions to take effect. Use
 Firewall blocking SMB from DC to attacker. Verify port 445 reachability. Try
 alternative coercion (WebDAV for HTTP coercion, or use a host the DC can reach).
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ### OPSEC comparison
 
 | ESC | OPSEC | Detection Surface |

--- a/skills/ad/adcs-persistence/SKILL.md
+++ b/skills/ad/adcs-persistence/SKILL.md
@@ -665,6 +665,17 @@ for obtaining intermediate account access.
 Mimikatz patches CAPI/CNG to bypass non-exportable flag:
 `mimikatz.exe "crypto::capi"` (current user) or `"crypto::cng"` (LSASS).
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ### OPSEC comparison
 
 | Technique | OPSEC | Detection Surface |

--- a/skills/ad/adcs-template-abuse/SKILL.md
+++ b/skills/ad/adcs-template-abuse/SKILL.md
@@ -525,6 +525,17 @@ NTAuth`.
 Template requires manager approval. Check if you have ManageCA/ManageCertificates
 permissions to approve it yourself — route to **adcs-access-and-relay** (ESC7).
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ### OPSEC comparison
 
 | ESC | OPSEC | Detection Surface |

--- a/skills/ad/auth-coercion-relay/SKILL.md
+++ b/skills/ad/auth-coercion-relay/SKILL.md
@@ -672,6 +672,20 @@ Default `ms-DS-MachineAccountQuota` is 10. If set to 0:
 - Use `--delegate-access` instead (modifies existing object)
 - Or relay to AD CS for certificate-based escalation
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This applies to the
+initial LDAP enumeration phase (authenticated coercion endpoint discovery), not
+to the relay attack itself (which uses NTLM). This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM for the Kerberos-authenticated operations. The fix requires
+root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ### OPSEC Comparison
 
 | Technique | Network Artifacts | Detection Events | Risk |

--- a/skills/ad/credential-dumping/SKILL.md
+++ b/skills/ad/credential-dumping/SKILL.md
@@ -631,7 +631,9 @@ Do not loop. Work through failures systematically:
 
 - Target may require SMB3, add `-smb2support` or check Impacket version
 - Try `-use-vss` flag for VSS-based extraction instead of DRSUAPI
-- Clock skew: `sudo ntpdate DC_IP` (requires root — present to user for manual execution)
+- Clock skew (`KRB_AP_ERR_SKEW`): **Clock Skew Interrupt** — stop immediately
+  and return to the orchestrator. Do not retry or fall back to NTLM. Fix
+  requires root: `sudo ntpdate DC_IP`
 
 ### LAPS Attribute Empty
 

--- a/skills/ad/gpo-abuse/SKILL.md
+++ b/skills/ad/gpo-abuse/SKILL.md
@@ -617,6 +617,17 @@ Do not loop. Work through failures systematically:
 - Check if the password was set after MS14-025 patch (post-2014 GPPs
   should not contain cpassword)
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ### OPSEC Comparison
 
 | Technique | OPSEC | Detection Events | Notes |

--- a/skills/ad/kerberos-delegation/SKILL.md
+++ b/skills/ad/kerberos-delegation/SKILL.md
@@ -557,11 +557,15 @@ For classic constrained delegation, S4U2Self must return a Forwardable ticket
 (requires `TrustedToAuthForDelegation` flag). For RBCD, non-Forwardable tickets
 work — the target computer validates RBCD differently.
 
-### KRB_AP_ERR_SKEW
+### KRB_AP_ERR_SKEW (Clock Skew)
 
-Clock skew > 5 minutes. Sync time (requires root — present to user for manual execution):
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
 ```bash
 sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
 ```
 
 ### RBCD: "Insufficient access rights" When Setting Attribute

--- a/skills/ad/kerberos-roasting/SKILL.md
+++ b/skills/ad/kerberos-roasting/SKILL.md
@@ -491,8 +491,9 @@ Do not loop. Work through failures systematically:
 
 ### KRB_AP_ERR_SKEW (Clock Skew)
 
-Kerberos requires clocks within 5 minutes. Sync with the DC (requires root —
-present to user for manual execution):
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
 ```bash
 sudo ntpdate DC_IP
 # or

--- a/skills/ad/kerberos-ticket-forging/SKILL.md
+++ b/skills/ad/kerberos-ticket-forging/SKILL.md
@@ -521,6 +521,17 @@ Check rotation history:
 Get-ADUser krbtgt -Properties PasswordLastSet
 ```
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ### Ticket Type Comparison
 
 | Ticket | Key Material | Scope | Detectability | Survives krbtgt Rotation |

--- a/skills/ad/pass-the-hash/SKILL.md
+++ b/skills/ad/pass-the-hash/SKILL.md
@@ -502,10 +502,13 @@ Do not loop. Work through failures systematically:
 
 ### KRB_AP_ERR_SKEW (Clock Skew)
 
-Kerberos requires clocks within 5 minutes of the DC (requires root — present
-to user for manual execution):
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
 ```bash
 sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
 ```
 
 ### KDC Cannot Find the Name / PyAsn1Error

--- a/skills/ad/password-spraying/SKILL.md
+++ b/skills/ad/password-spraying/SKILL.md
@@ -553,11 +553,16 @@ Do not loop. Work through failures systematically:
 - **Recovery**: Lockout duration is typically 30 minutes. Wait and resume
   with fewer attempts per round
 
-### KRB_AP_ERR_SKEW (kerbrute)
+### KRB_AP_ERR_SKEW (Clock Skew — kerbrute path only)
 
-Clock out of sync. Fix with (requires root — present to user for manual execution):
+Kerberos requires clocks within 5 minutes of the DC. This applies to the
+kerbrute-based spraying path, not NTLM-based spraying. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
 ```bash
-sudo ntpdate DC01.DOMAIN.LOCAL
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
 ```
 
 ### Kerberos Pre-Auth vs NTLM Detection

--- a/skills/ad/sccm-exploitation/SKILL.md
+++ b/skills/ad/sccm-exploitation/SKILL.md
@@ -588,6 +588,17 @@ Do not loop. Work through failures systematically:
 - Verify device is in the collection: `MalSCCM.exe inspect /groups`
 - Check SCCM client logs on target: `C:\Windows\CCM\Logs\`
 
+### KRB_AP_ERR_SKEW (Clock Skew)
+
+Kerberos requires clocks within 5 minutes of the DC. This is a **Clock Skew
+Interrupt** — stop immediately and return to the orchestrator. Do not retry or
+fall back to NTLM. The fix requires root:
+```bash
+sudo ntpdate DC_IP
+# or
+sudo rdate -n DC_IP
+```
+
 ## OPSEC Comparison
 
 | Technique | OPSEC | Detection | Prerequisites |

--- a/skills/ad/trust-attacks/SKILL.md
+++ b/skills/ad/trust-attacks/SKILL.md
@@ -506,8 +506,9 @@ Do not loop. Work through failures systematically:
 
 ### Cross-Forest Access Denied
 
-- **Clock skew**: Ensure time sync between forests: `sudo ntpdate TARGET_DC`
-  (requires root — present to user for manual execution).
+- **Clock skew** (`KRB_AP_ERR_SKEW`): **Clock Skew Interrupt** — stop
+  immediately and return to the orchestrator. Do not retry or fall back to
+  NTLM. Fix requires root: `sudo ntpdate TARGET_DC`
 - **DNS resolution**: Target DC must be resolvable. Add `/etc/hosts` entries
   or configure DNS forwarding.
 - **Service ticket refused**: Verify the service exists and the trust account


### PR DESCRIPTION
## Summary

- All 16 AD skills now detect `KRB_AP_ERR_SKEW` and interrupt cleanly instead of failing silently or retrying in a loop
- Each skill's troubleshooting section includes a Clock Skew Interrupt block that returns control to the orchestrator with a clear failure reason
- Orchestrator gains a Clock Skew Recovery handler that writes a `temp_clock-sync.sh` script (requires sudo for ntpdate), waits for operator confirmation, then retries the same skill invocation
- `ad-agent.md` updated with clock skew awareness instructions

## Changes

- **Orchestrator** (`skills/orchestrator/SKILL.md`): New "Clock Skew Recovery" section in vulnerability chaining
- **AD agent** (`agents/ad-agent.md`): Clock skew interrupt instructions added
- **16 AD skills** updated with Clock Skew Interrupt troubleshooting block:
  `acl-abuse`, `ad-discovery`, `ad-persistence`, `adcs-access-and-relay`, `adcs-persistence`, `adcs-template-abuse`, `auth-coercion-relay`, `credential-dumping`, `gpo-abuse`, `kerberos-delegation`, `kerberos-roasting`, `kerberos-ticket-forging`, `pass-the-hash`, `password-spraying`, `sccm-exploitation`, `trust-attacks`

## Test plan

- [x] Run `./install.sh` — verify clean install
- [x] Verify `search_skills("clock skew")` returns AD skills with updated content
- [x] Test against a target with >5min clock delta — confirm interrupt triggers and recovery script works
- [x] Verify skills that note Kerberos N/A (`auth-coercion-relay`, `password-spraying`) still include the block for mixed workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)