### PR TITLE
Add skill testing framework and CI workflow

### DIFF
--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -1,0 +1,16 @@
+name: Skill Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - name: Install dependencies
+        run: cd tools/skill-router && uv sync --only-group lint
+      - name: Run skill lint tests
+        run: cd tools/skill-router && uv run --only-group lint pytest tests/test_skills.py tests/test_agents.py -v

--- a/skills/network/network-recon/SKILL.md
+++ b/skills/network/network-recon/SKILL.md
@@ -869,3 +869,22 @@ web app with known vuln > database with creds > default service access).
 When routing, pass along: target IP, open ports, identified services and versions,
 OS, any credentials or access found, current mode.
 
+## Troubleshooting
+
+### Nmap scan runs slowly or hangs
+- Use `-T4` for speed. Drop to `-T3` if getting rate-limited or missing ports.
+- On large subnets, start with `--top-ports 1000` before doing `-p-`.
+- If host seems down but you know it's up, add `-Pn` to skip host discovery.
+
+### UDP scan takes too long
+- UDP scans are inherently slow. Limit to key ports: `-sU -p 53,67,69,123,161,162,500,623,1434,5353`.
+- Combine with TCP: `-sS -sU --top-ports 100`.
+
+### Service version detection returns "tcpwrapped"
+- Target is accepting TCP connections but dropping them before service negotiation.
+- Try connecting manually: `nc -nv TARGET_IP PORT` to see if there's a banner.
+- May indicate a firewall or IPS is interfering.
+
+### Nmap XML parsing fails
+- Ensure scan completed (check for `</nmaprun>` closing tag).
+- If scan was interrupted, partial XML is unusable — re-run with `-oA` to get all formats.

--- a/tools/skill-router/pyproject.toml
+++ b/tools/skill-router/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
 dev = [
     "pytest>=8.0",
 ]
+lint = [
+    "pytest>=8.0",
+    "pyyaml>=6.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/tools/skill-router/tests/test_index.py
+++ b/tools/skill-router/tests/test_index.py
@@ -1,0 +1,146 @@
+"""Index tests for ChromaDB skill collection.
+
+Validates that all indexable skills are present in the collection, no stale
+entries exist, and semantic search returns expected results. Requires ChromaDB
+built via install.sh — skips if .chromadb/ doesn't exist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# --- Paths ---
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+DB_DIR = Path(__file__).resolve().parent.parent / ".chromadb"
+
+# Same exclusion rules as indexer.py
+SKIP_DIRS = {"_template"}
+NATIVE_SKILLS = {"orchestrator"}
+
+
+def _get_indexable_skill_names() -> set[str]:
+    """Return set of skill directory names that should be indexed."""
+    names = set()
+    for path in SKILLS_DIR.rglob("SKILL.md"):
+        relative = path.relative_to(SKILLS_DIR)
+        if any(part in SKIP_DIRS for part in relative.parts):
+            continue
+        if path.parent.name in NATIVE_SKILLS:
+            continue
+        names.add(path.parent.name)
+    return names
+
+
+# --- Skip if ChromaDB not built ---
+
+if not DB_DIR.exists():
+    pytest.skip("ChromaDB not built — run install.sh first", allow_module_level=True)
+
+# Import ChromaDB only after confirming it exists (avoids import errors in lint-only CI)
+from server import _get_collection  # noqa: E402
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture(scope="module")
+def collection():
+    """Return the ChromaDB collection."""
+    return _get_collection(DB_DIR)
+
+
+@pytest.fixture(scope="module")
+def indexed_ids(collection) -> set[str]:
+    """Return all IDs currently in the collection."""
+    results = collection.get()
+    return set(results["ids"])
+
+
+@pytest.fixture(scope="module")
+def skill_names() -> set[str]:
+    """Return all indexable skill directory names."""
+    return _get_indexable_skill_names()
+
+
+# --- Index Completeness Tests ---
+
+
+class TestIndexCompleteness:
+    def test_all_skills_indexed(self, indexed_ids: set[str], skill_names: set[str]):
+        """Every indexable skill should be present in the collection."""
+        missing = skill_names - indexed_ids
+        assert not missing, (
+            f"{len(missing)} skill(s) not indexed: {sorted(missing)}. "
+            f"Re-run: uv run python indexer.py"
+        )
+
+    def test_no_stale_entries(self, indexed_ids: set[str], skill_names: set[str]):
+        """Every ID in the collection should correspond to an existing skill."""
+        stale = indexed_ids - skill_names
+        assert not stale, (
+            f"{len(stale)} stale entry/entries in index: {sorted(stale)}. "
+            f"Re-run: uv run python indexer.py"
+        )
+
+
+# --- Round-Trip Tests ---
+
+
+class TestGetSkillRoundTrip:
+    @pytest.fixture(
+        params=sorted(_get_indexable_skill_names()),
+        ids=lambda n: n,
+    )
+    def skill_name(self, request: pytest.FixtureRequest) -> str:
+        return request.param
+
+    def test_get_skill_returns_content(self, collection, skill_name: str):
+        """collection.get(ids=[name]) returns a result with a valid path."""
+        results = collection.get(ids=[skill_name], include=["metadatas"])
+        assert results["ids"], f"Skill '{skill_name}' not found in collection"
+
+        metadata = results["metadatas"][0]
+        assert "path" in metadata, f"Skill '{skill_name}' metadata missing 'path'"
+        path = Path(metadata["path"])
+        assert path.exists(), (
+            f"Skill '{skill_name}' indexed path does not exist: {path}"
+        )
+
+
+# --- Search Quality Tests ---
+
+
+class TestSearchQuality:
+    """Smoke tests: canonical queries must return the expected skill as top-1."""
+
+    QUERIES = [
+        ("SQL injection with UNION SELECT", "sql-injection-union"),
+        ("Kerberos roasting attack", "kerberos-roasting"),
+        ("Linux kernel exploit DirtyPipe PwnKit CVE", "linux-kernel-exploits"),
+        ("SSRF server-side request forgery internal service", "ssrf"),
+        ("Tomcat WAR deployment", "tomcat-manager-deploy"),
+        ("lxd group privilege escalation", "linux-file-path-abuse"),
+        ("Active Directory certificate abuse", "adcs-template-abuse"),
+        ("Blind XPath/NoSQL injection", "nosql-injection"),
+    ]
+
+    @pytest.fixture(params=QUERIES, ids=lambda q: q[1])
+    def query_and_expected(self, request: pytest.FixtureRequest) -> tuple[str, str]:
+        return request.param
+
+    def test_top1_result(self, collection, query_and_expected: tuple[str, str]):
+        query, expected = query_and_expected
+        results = collection.query(
+            query_texts=[query],
+            n_results=1,
+            include=["distances"],
+        )
+        assert results["ids"][0], f"No results for query: {query}"
+        top1 = results["ids"][0][0]
+        assert top1 == expected, (
+            f"Query '{query}': expected top-1 '{expected}', got '{top1}'"
+        )

--- a/tools/skill-router/tests/test_skills.py
+++ b/tools/skill-router/tests/test_skills.py
@@ -1,0 +1,242 @@
+"""Lint tests for SKILL.md files.
+
+Validates skill frontmatter (required fields, name consistency, opsec values)
+and required body sections. No network, no MCP server, no ChromaDB — reads
+skill files directly. Only requires pyyaml + pytest.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# --- Paths ---
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+
+# Skills excluded from indexing (same rules as indexer.py)
+SKIP_DIRS = {"_template"}
+NATIVE_SKILLS = {"orchestrator"}
+
+# Sections required for all indexed skills (except retrospective)
+REQUIRED_SECTIONS = {
+    "## Mode",
+    "## Engagement Logging",
+    "## State Management",
+    "## Prerequisites",
+    "## Troubleshooting",
+}
+
+# Retrospective is a post-mortem skill — no target interaction, different structure
+RETROSPECTIVE_REQUIRED_SECTIONS = {
+    "## Prerequisites",
+    "## Troubleshooting",
+    "## Engagement Logging",
+}
+
+REQUIRED_FRONTMATTER_FIELDS = {"name", "description", "keywords", "tools", "opsec"}
+VALID_OPSEC_VALUES = {"low", "medium", "high"}
+
+# Template placeholders that should not appear in real skills
+TEMPLATE_PLACEHOLDERS = {
+    "<skill-name>",
+    "<technique description>",
+    "<scope>",
+}
+
+
+# --- Helpers ---
+
+
+def _get_skill_files() -> list[Path]:
+    """Return all indexable SKILL.md paths (excludes _template and orchestrator)."""
+    if not SKILLS_DIR.exists():
+        return []
+    files = []
+    for path in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        relative = path.relative_to(SKILLS_DIR)
+        if any(part in SKIP_DIRS for part in relative.parts):
+            continue
+        if path.parent.name in NATIVE_SKILLS:
+            continue
+        files.append(path)
+    return files
+
+
+def _parse_skill_frontmatter(path: Path) -> dict:
+    """Parse YAML frontmatter from a SKILL.md file."""
+    content = path.read_text()
+    if not content.startswith("---"):
+        pytest.fail(f"{path}: missing YAML frontmatter (must start with ---)")
+
+    match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        pytest.fail(f"{path}: malformed YAML frontmatter (no closing ---)")
+
+    try:
+        return yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError as e:
+        pytest.fail(f"{path}: invalid YAML frontmatter: {e}")
+
+
+def _get_all_skill_names() -> set[str]:
+    """Return set of directory names for all indexable skills."""
+    return {p.parent.name for p in _get_skill_files()}
+
+
+def _get_all_skill_md_paths() -> list[Path]:
+    """Return all SKILL.md paths including orchestrator (for routing ref checks)."""
+    if not SKILLS_DIR.exists():
+        return []
+    files = []
+    for path in sorted(SKILLS_DIR.rglob("SKILL.md")):
+        relative = path.relative_to(SKILLS_DIR)
+        if any(part in SKIP_DIRS for part in relative.parts):
+            continue
+        files.append(path)
+    return files
+
+
+def _skill_id(path: Path) -> str:
+    """Return a readable test ID from a skill path (e.g., 'web/sql-injection-union')."""
+    relative = path.relative_to(SKILLS_DIR)
+    return str(relative.parent)
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture(params=_get_skill_files(), ids=lambda p: _skill_id(p))
+def skill_file(request: pytest.FixtureRequest) -> Path:
+    return request.param
+
+
+@pytest.fixture
+def skill_frontmatter(skill_file: Path) -> dict:
+    return _parse_skill_frontmatter(skill_file)
+
+
+# --- Frontmatter Tests ---
+
+
+class TestSkillFrontmatter:
+    def test_has_required_fields(self, skill_file: Path, skill_frontmatter: dict):
+        missing = REQUIRED_FRONTMATTER_FIELDS - set(skill_frontmatter.keys())
+        assert not missing, f"{_skill_id(skill_file)}: missing fields: {missing}"
+
+    def test_name_matches_directory(self, skill_file: Path, skill_frontmatter: dict):
+        expected = skill_file.parent.name
+        actual = skill_frontmatter.get("name", "")
+        assert actual == expected, (
+            f"{_skill_id(skill_file)}: frontmatter name '{actual}' "
+            f"doesn't match directory name '{expected}'"
+        )
+
+    def test_keywords_nonempty(self, skill_file: Path, skill_frontmatter: dict):
+        keywords = skill_frontmatter.get("keywords", [])
+        assert isinstance(keywords, list) and len(keywords) >= 1, (
+            f"{_skill_id(skill_file)}: keywords must be a non-empty list"
+        )
+
+    def test_opsec_valid(self, skill_file: Path, skill_frontmatter: dict):
+        opsec = str(skill_frontmatter.get("opsec", "")).strip()
+        assert opsec in VALID_OPSEC_VALUES, (
+            f"{_skill_id(skill_file)}: opsec '{opsec}' not in {VALID_OPSEC_VALUES}"
+        )
+
+    def test_description_not_empty(self, skill_file: Path, skill_frontmatter: dict):
+        desc = skill_frontmatter.get("description", "")
+        assert isinstance(desc, str) and len(desc.strip()) > 20, (
+            f"{_skill_id(skill_file)}: description must be >20 chars, "
+            f"got {len(str(desc).strip())} chars"
+        )
+
+
+# --- Section Tests ---
+
+
+class TestSkillSections:
+    def test_has_required_sections(self, skill_file: Path):
+        content = skill_file.read_text()
+        skill_name = skill_file.parent.name
+
+        if skill_name == "retrospective":
+            required = RETROSPECTIVE_REQUIRED_SECTIONS
+        else:
+            required = REQUIRED_SECTIONS
+
+        missing = []
+        for section in required:
+            if section not in content:
+                missing.append(section)
+
+        assert not missing, (
+            f"{_skill_id(skill_file)}: missing required sections: {missing}"
+        )
+
+
+# --- Routing Reference Tests ---
+
+
+class TestSkillRouting:
+    def test_no_old_routing_refs(self):
+        """No skills should use the old 'Invoke **X** via the Skill tool' pattern."""
+        old_pattern = re.compile(r"Invoke \*\*.*?\*\* via the Skill tool")
+        violations = []
+
+        for path in _get_all_skill_md_paths():
+            content = path.read_text()
+            for i, line in enumerate(content.splitlines(), 1):
+                if old_pattern.search(line):
+                    violations.append(f"{_skill_id(path)}:{i}: {line.strip()}")
+
+        assert not violations, (
+            f"Found old routing pattern in {len(violations)} location(s):\n"
+            + "\n".join(violations)
+        )
+
+    def test_get_skill_refs_valid(self):
+        """Every get_skill('X') reference must point to an existing skill."""
+        known = _get_all_skill_names()
+        # Documentation examples use placeholder names — skip them
+        placeholder_refs = {"skill-name"}
+        ref_pattern = re.compile(r'get_skill\(["\']([^"\']+)["\']\)')
+        invalid = []
+
+        for path in _get_all_skill_md_paths():
+            content = path.read_text()
+            for match in ref_pattern.finditer(content):
+                ref_name = match.group(1)
+                if ref_name in placeholder_refs:
+                    continue
+                if ref_name not in known:
+                    invalid.append(f"{_skill_id(path)}: get_skill(\"{ref_name}\")")
+
+        assert not invalid, (
+            f"Found {len(invalid)} get_skill() ref(s) to non-existent skills:\n"
+            + "\n".join(invalid)
+        )
+
+    def test_no_template_placeholders(self):
+        """Indexed skills must not contain template placeholder literals."""
+        # Retrospective uses <skill-name> as output format instructions, not as
+        # an unfilled template placeholder
+        excluded = {"retrospective"}
+        violations = []
+
+        for path in _get_skill_files():
+            if path.parent.name in excluded:
+                continue
+            content = path.read_text()
+            for placeholder in TEMPLATE_PLACEHOLDERS:
+                if placeholder in content:
+                    violations.append(f"{_skill_id(path)}: contains '{placeholder}'")
+
+        assert not violations, (
+            f"Found template placeholders in {len(violations)} location(s):\n"
+            + "\n".join(violations)
+        )


### PR DESCRIPTION
## Summary

- **Skill lint tests** (`test_skills.py`, 399 tests) — frontmatter validation, required sections, routing ref checks, template placeholder detection
- **Index tests** (`test_index.py`, 76 tests) — index completeness, get_skill round-trip, search quality smoke tests (8 canonical queries)
- **CI workflow** (`.github/workflows/skill-lint.yml`) — runs lint tests on PRs to main, ~9s with `--only-group lint` (skips chromadb/torch)
- **Lint dependency group** in `pyproject.toml` — pytest + pyyaml only, avoids 3GB of ML deps in CI
- **network-recon fix** — added missing `## Troubleshooting` section

## Test plan

- [x] `uv run pytest tests/test_skills.py -v` — 399 passed
- [x] `uv run pytest tests/test_index.py -v` — 76 passed (requires local ChromaDB)
- [x] `uv run pytest tests/ -v` — 523 total, all green
- [x] CI rejects bad skill (6 expected failures) — verified via fork PR
- [x] CI passes good skill in 9s — verified via fork PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)