### PR TITLE
Dockerize nmap MCP server and add input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each invocation: agent loads one skill, follows the methodology, saves evidence,
 
 **MCP servers:**
 - **skill-router** — semantic search + skill loading via ChromaDB + sentence-transformer embeddings
-- **nmap-server** — wraps `sudo nmap`, returns parsed JSON (to do: Dockerize this)
+- **nmap-server** — runs nmap inside a Docker container, returns parsed JSON with input validation
 - **shell-server** — TCP listener + reverse shell session manager
 - **state-server** — SQLite engagement state
 
@@ -125,7 +125,7 @@ The cycle is: **engage → retrospective → improve skills → engage again**. 
 
 - Linux VM with your pentesting tools installed
 - [uv](https://docs.astral.sh/uv/) — Python package manager (for MCP servers)
-- Passwordless `sudo nmap` — the install script checks for this and advises how to configure it if missing
+- [Docker](https://docs.docker.com/engine/install/) — the nmap MCP server runs scans inside a container (the install script builds the image)
 
 ### Install
 
@@ -145,7 +145,7 @@ The installer:
 2. Installs `orchestrator` as a native Claude Code skill (`~/.claude/skills/`)
 3. Installs **custom subagents** to `~/.claude/agents/`
 4. Sets up **MCP servers** — `skill-router` (ChromaDB + embeddings), `nmap-server`, `shell-server`, `state-server`
-5. Verifies project config (`.mcp.json`, settings, passwordless sudo nmap)
+5. Verifies project config (`.mcp.json`, settings, Docker for nmap)
 
 The repo must stay in place — the MCP server reads skills from `skills/` at runtime.
 

--- a/agents/network-recon-agent.md
+++ b/agents/network-recon-agent.md
@@ -44,8 +44,8 @@ You have access to the `nmap_scan` MCP tool from the nmap-server. Use it
 instead of the sudo handoff protocol described in the skill text.
 
 - Call `nmap_scan(target="<ip>", options="<nmap flags>")` to run scans.
-- The tool runs `sudo nmap` and returns parsed JSON with hosts, ports,
-  services, scripts, and OS detection.
+- The tool runs nmap inside a Docker container and returns parsed JSON with
+  hosts, ports, services, scripts, and OS detection.
 - Raw XML is automatically saved to `engagement/evidence/` if the directory
   exists.
 - For host discovery scans, use `nmap_scan(target="<range>", options="-sn -PE -PS22,80,135,443,445")`.
@@ -53,8 +53,8 @@ instead of the sudo handoff protocol described in the skill text.
   `-A -p- -T4`.
 
 **When the skill text says "write a handoff script" or "present the sudo
-command to the user"**, use `nmap_scan` instead. The MCP server handles sudo
-transparently.
+command to the user"**, use `nmap_scan` instead. The MCP server handles Docker
+execution transparently.
 
 ## Reverse Shell via MCP
 

--- a/install.sh
+++ b/install.sh
@@ -176,14 +176,15 @@ uv run --directory "${MCP_SKILL_ROUTER}" python indexer.py
 echo "  [nmap-server] Installing Python dependencies..."
 uv sync --directory "${MCP_NMAP_SERVER}" --quiet
 
-# Check sudo nmap availability
-if sudo -n nmap --version &>/dev/null 2>&1; then
-    echo "  [nmap-server] sudo nmap: OK"
+# Build Docker image for nmap
+if command -v docker &>/dev/null && docker info &>/dev/null 2>&1; then
+    echo "  [nmap-server] Building Docker image..."
+    docker build -t red-run-nmap:latest "${MCP_NMAP_SERVER}" --quiet
+    echo "  [nmap-server] Docker image: OK"
 else
     echo ""
-    echo "  WARNING: passwordless sudo for nmap not configured."
-    echo "  The nmap MCP server requires it. Add to /etc/sudoers.d/nmap:"
-    echo "    $USER ALL=(root) NOPASSWD: /usr/bin/nmap"
+    echo "  WARNING: Docker required for nmap MCP server but not available."
+    echo "  Install Docker and ensure the daemon is running, then re-run install.sh."
     echo ""
 fi
 
@@ -217,7 +218,7 @@ echo ""
 echo "Installed ${native_count} native skill(s) to ${SKILLS_DST}/ (${MODE} mode)"
 echo "Installed ${agent_count} custom subagent(s) to ${AGENTS_DST}/"
 echo "63 technique/discovery skills served via MCP skill-router"
-echo "nmap MCP server ready (sudo nmap wrapper)"
+echo "nmap MCP server ready (Dockerized nmap)"
 echo "shell MCP server ready (TCP listener + reverse shell manager)"
 echo "state MCP server ready (SQLite engagement state)"
 if [[ "$config_warnings" -eq 0 ]]; then

--- a/tools/nmap-server/Dockerfile
+++ b/tools/nmap-server/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache nmap nmap-scripts
+
+ENTRYPOINT ["nmap"]

--- a/tools/nmap-server/README.md
+++ b/tools/nmap-server/README.md
@@ -1,35 +1,29 @@
 # nmap MCP Server
 
-MCP server wrapping `sudo nmap` for red-run subagents. Eliminates the sudo
-handoff bottleneck — subagents call `nmap_scan` directly and get structured
-JSON back.
+MCP server running nmap inside a Docker container for red-run subagents.
+Eliminates the sudo attack surface — nmap runs in an isolated container with
+minimal capabilities, and all inputs are validated before execution.
 
 ## Prerequisites
 
-### 1. Install nmap
+### 1. Install Docker
 
 ```bash
 # Debian/Ubuntu
-sudo apt install nmap
+sudo apt install docker.io
+sudo usermod -aG docker $USER
+# Log out and back in for group change to take effect
 
-# Arch
-sudo pacman -S nmap
+# Or install Docker Engine: https://docs.docker.com/engine/install/
 ```
 
-### 2. Configure passwordless sudo for nmap
-
-Create a sudoers drop-in file:
+### 2. Build the nmap image
 
 ```bash
-echo "$USER ALL=(root) NOPASSWD: /usr/bin/nmap" | sudo tee /etc/sudoers.d/nmap
-sudo chmod 440 /etc/sudoers.d/nmap
+docker build -t red-run-nmap:latest tools/nmap-server/
 ```
 
-Verify it works:
-
-```bash
-sudo -n nmap --version
-```
+The `install.sh` script does this automatically.
 
 ### 3. Install Python dependencies
 
@@ -50,7 +44,7 @@ uv run --directory tools/nmap-server python server.py
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `nmap_scan` | `target` (required), `options` (default `-A -p- -T4`), `save_to` (optional path) | Run sudo nmap, return parsed JSON |
+| `nmap_scan` | `target` (required), `options` (default `-A -p- -T4`), `save_to` (optional path) | Run nmap in Docker, return parsed JSON |
 | `get_scan` | `scan_id` | Retrieve previous scan results |
 | `list_scans` | (none) | List all session scans |
 
@@ -59,6 +53,30 @@ uv run --directory tools/nmap-server python server.py
 | Env Variable | Default | Description |
 |-------------|---------|-------------|
 | `NMAP_TIMEOUT` | `600` | Max scan duration in seconds |
+| `NMAP_DOCKER_IMAGE` | `red-run-nmap:latest` | Docker image to use for nmap |
+
+## Security
+
+### Container isolation
+
+Nmap runs inside a minimal Alpine container with:
+- `--network=host` for raw socket access to the target network
+- `--cap-drop=ALL --cap-add=NET_RAW --cap-add=NET_ADMIN` — only network capabilities
+- `--rm` — container is removed after each scan
+- No volume mounts — XML output goes to stdout, evidence saved by the host-side MCP server
+
+### Input validation
+
+All inputs are validated before reaching `subprocess.run()`:
+
+- **Options**: Blocklist of dangerous flags (`-iL`, `-oN`, `--datadir`, etc.)
+  that could read/write files or override paths. `--script` arguments must be
+  bare names (no paths or URLs).
+- **Target**: Blocks shell metacharacters (`;|&` etc.), path traversal (`..`),
+  and whitespace injection.
+- **save_to**: Resolved path must be under `engagement/evidence/`.
+- **Filename sanitization**: Target strings used in evidence filenames are
+  stripped of unsafe characters.
 
 ## Output
 

--- a/tools/nmap-server/pyproject.toml
+++ b/tools/nmap-server/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "red-run-nmap-server"
 version = "0.1.0"
-description = "MCP server wrapping sudo nmap for Claude Code subagents"
+description = "MCP server running nmap in Docker for Claude Code subagents"
 requires-python = ">=3.10"
 dependencies = [
     "mcp[cli]>=1.4.1",

--- a/tools/nmap-server/tests/test_validate.py
+++ b/tools/nmap-server/tests/test_validate.py
@@ -1,0 +1,287 @@
+"""Tests for nmap input validation.
+
+Tests every blocked flag, allowed flags, --script name vs path, target
+metacharacters, save_to traversal, and filename sanitization.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from validate import (
+    ValidationError,
+    sanitize_target_for_filename,
+    validate_options,
+    validate_save_to,
+    validate_target,
+)
+
+
+# --- validate_options ---
+
+
+class TestValidateOptions:
+    """Tests for option string validation."""
+
+    def test_allows_common_scan_flags(self):
+        args = validate_options("-A -p- -T4")
+        assert args == ["-A", "-p-", "-T4"]
+
+    def test_allows_port_specification(self):
+        args = validate_options("-p 22,80,443")
+        assert args == ["-p", "22,80,443"]
+
+    def test_allows_ping_scan(self):
+        args = validate_options("-sn -PE -PS22,80")
+        assert args == ["-sn", "-PE", "-PS22,80"]
+
+    def test_allows_version_detection(self):
+        args = validate_options("-sV --version-intensity 5")
+        assert args == ["-sV", "--version-intensity", "5"]
+
+    def test_allows_timing_template(self):
+        args = validate_options("-T3")
+        assert args == ["-T3"]
+
+    def test_allows_safe_script_names(self):
+        args = validate_options("--script default")
+        assert "--script" in args
+        assert "default" in args
+
+    def test_allows_script_with_equals(self):
+        args = validate_options("--script=vuln,safe")
+        assert "--script=vuln,safe" in args
+
+    def test_allows_script_wildcards(self):
+        args = validate_options("--script http-*")
+        assert "http-*" in args
+
+    def test_allows_script_categories(self):
+        args = validate_options("--script smb-enum-shares,smb-enum-users")
+        assert "smb-enum-shares,smb-enum-users" in args
+
+    def test_allows_empty_options(self):
+        args = validate_options("")
+        assert args == []
+
+    # --- Blocked file-read flags ---
+
+    def test_blocks_iL(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*-iL"):
+            validate_options("-iL /etc/passwd")
+
+    def test_blocks_excludefile(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--excludefile"):
+            validate_options("--excludefile /tmp/exclude.txt")
+
+    def test_blocks_resume(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--resume"):
+            validate_options("--resume /tmp/nmap.xml")
+
+    def test_blocks_servicedb(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--servicedb"):
+            validate_options("--servicedb /etc/services")
+
+    def test_blocks_versiondb(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--versiondb"):
+            validate_options("--versiondb /tmp/probes")
+
+    # --- Blocked file-write flags ---
+
+    def test_blocks_oN(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*-oN"):
+            validate_options("-oN /tmp/out.txt")
+
+    def test_blocks_oG(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*-oG"):
+            validate_options("-oG /tmp/out.gnmap")
+
+    def test_blocks_oX(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*-oX"):
+            validate_options("-oX /tmp/out.xml")
+
+    def test_blocks_oA(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*-oA"):
+            validate_options("-oA /tmp/out")
+
+    def test_blocks_append_output(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--append-output"):
+            validate_options("--append-output -oN /tmp/out.txt")
+
+    # --- Blocked path-override flags ---
+
+    def test_blocks_datadir(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--datadir"):
+            validate_options("--datadir /tmp/nmap-data")
+
+    def test_blocks_script_updatedb(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--script-updatedb"):
+            validate_options("--script-updatedb")
+
+    def test_blocks_script_path(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--script-path"):
+            validate_options("--script-path /tmp/scripts")
+
+    def test_blocks_script_args_file(self):
+        with pytest.raises(ValidationError, match="Blocked flag.*--script-args-file"):
+            validate_options("--script-args-file /tmp/args.txt")
+
+    # --- Blocked --script paths ---
+
+    def test_blocks_script_with_path(self):
+        with pytest.raises(ValidationError, match="Blocked --script value"):
+            validate_options("--script /tmp/evil.nse")
+
+    def test_blocks_script_with_relative_path(self):
+        with pytest.raises(ValidationError, match="Blocked --script value"):
+            validate_options("--script ./evil.nse")
+
+    def test_blocks_script_with_equals_path(self):
+        with pytest.raises(ValidationError, match="Blocked --script value"):
+            validate_options("--script=/tmp/evil.nse")
+
+    # --- Malformed input ---
+
+    def test_blocks_malformed_quotes(self):
+        with pytest.raises(ValidationError, match="Malformed"):
+            validate_options('-A "unclosed quote')
+
+
+# --- validate_target ---
+
+
+class TestValidateTarget:
+    """Tests for target string validation."""
+
+    def test_allows_ipv4(self):
+        assert validate_target("10.10.10.5") == "10.10.10.5"
+
+    def test_allows_cidr(self):
+        assert validate_target("10.10.10.0/24") == "10.10.10.0/24"
+
+    def test_allows_hostname(self):
+        assert validate_target("target.htb") == "target.htb"
+
+    def test_allows_subdomain(self):
+        assert validate_target("app.target.htb") == "app.target.htb"
+
+    def test_blocks_empty_target(self):
+        with pytest.raises(ValidationError, match="cannot be empty"):
+            validate_target("")
+
+    def test_blocks_whitespace_only(self):
+        with pytest.raises(ValidationError, match="cannot be empty"):
+            validate_target("   ")
+
+    def test_blocks_path_traversal(self):
+        with pytest.raises(ValidationError, match="path traversal"):
+            validate_target("../../etc/passwd")
+
+    def test_blocks_semicolon(self):
+        with pytest.raises(ValidationError, match="shell metacharacters"):
+            validate_target("10.10.10.5; rm -rf /")
+
+    def test_blocks_pipe(self):
+        with pytest.raises(ValidationError, match="shell metacharacters"):
+            validate_target("10.10.10.5 | cat /etc/passwd")
+
+    def test_blocks_ampersand(self):
+        with pytest.raises(ValidationError, match="shell metacharacters"):
+            validate_target("10.10.10.5 & whoami")
+
+    def test_blocks_backtick(self):
+        with pytest.raises(ValidationError, match="shell metacharacters"):
+            validate_target("`whoami`")
+
+    def test_blocks_dollar_paren(self):
+        with pytest.raises(ValidationError, match="shell metacharacters"):
+            validate_target("$(whoami)")
+
+    def test_blocks_braces(self):
+        with pytest.raises(ValidationError, match="shell metacharacters"):
+            validate_target("{echo,test}")
+
+    def test_blocks_whitespace_injection(self):
+        with pytest.raises(ValidationError, match="whitespace"):
+            validate_target("10.10.10.5 -iL /etc/passwd")
+
+
+# --- validate_save_to ---
+
+
+class TestValidateSaveTo:
+    """Tests for save_to path validation."""
+
+    def test_allows_path_under_evidence(self, tmp_path):
+        evidence_dir = tmp_path / "engagement" / "evidence"
+        evidence_dir.mkdir(parents=True)
+        result = validate_save_to("engagement/evidence/scan.xml", tmp_path)
+        assert result == evidence_dir / "scan.xml"
+
+    def test_allows_nested_path_under_evidence(self, tmp_path):
+        evidence_dir = tmp_path / "engagement" / "evidence" / "nmap"
+        evidence_dir.mkdir(parents=True)
+        result = validate_save_to("engagement/evidence/nmap/scan.xml", tmp_path)
+        assert result == evidence_dir / "scan.xml"
+
+    def test_blocks_path_outside_evidence(self, tmp_path):
+        (tmp_path / "engagement" / "evidence").mkdir(parents=True)
+        with pytest.raises(ValidationError, match="must be under"):
+            validate_save_to("/etc/passwd", tmp_path)
+
+    def test_blocks_traversal_out_of_evidence(self, tmp_path):
+        (tmp_path / "engagement" / "evidence").mkdir(parents=True)
+        with pytest.raises(ValidationError, match="must be under"):
+            validate_save_to("engagement/evidence/../../etc/passwd", tmp_path)
+
+    def test_blocks_empty_save_to(self):
+        with pytest.raises(ValidationError, match="cannot be empty"):
+            validate_save_to("", Path("/tmp"))
+
+    def test_blocks_engagement_root(self, tmp_path):
+        (tmp_path / "engagement" / "evidence").mkdir(parents=True)
+        with pytest.raises(ValidationError, match="must be under"):
+            validate_save_to("engagement/state.db", tmp_path)
+
+
+# --- sanitize_target_for_filename ---
+
+
+class TestSanitizeTargetForFilename:
+    """Tests for filename sanitization."""
+
+    def test_ipv4(self):
+        assert sanitize_target_for_filename("10.10.10.5") == "10.10.10.5"
+
+    def test_cidr_slash(self):
+        result = sanitize_target_for_filename("10.10.10.0/24")
+        assert "/" not in result
+        assert result == "10.10.10.0_24"
+
+    def test_dotdot_traversal(self):
+        result = sanitize_target_for_filename("../../etc/passwd")
+        assert ".." not in result
+        assert "/" not in result
+
+    def test_hostname(self):
+        assert sanitize_target_for_filename("target.htb") == "target.htb"
+
+    def test_shell_metacharacters(self):
+        result = sanitize_target_for_filename("10.10.10.5;rm -rf /")
+        assert ";" not in result
+        assert " " not in result
+
+    def test_empty_string(self):
+        assert sanitize_target_for_filename("") == "unknown"
+
+    def test_only_special_chars(self):
+        assert sanitize_target_for_filename(";;;") == "unknown"
+
+    def test_backslash(self):
+        result = sanitize_target_for_filename("foo\\bar")
+        assert "\\" not in result

--- a/tools/nmap-server/validate.py
+++ b/tools/nmap-server/validate.py
@@ -1,0 +1,159 @@
+"""Input validation for the nmap MCP server.
+
+Blocks dangerous nmap flags, shell metacharacters, and path traversal
+attempts. Defense-in-depth against prompt injection — even though nmap runs
+inside a Docker container, we validate inputs before they reach subprocess.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+# --- Blocked nmap flags ---
+
+# Flags that read arbitrary files from the filesystem
+_FILE_READ_FLAGS = frozenset({
+    "-iL", "--excludefile", "--resume", "--servicedb", "--versiondb",
+})
+
+# Flags that write files (we control output via -oX -)
+_FILE_WRITE_FLAGS = frozenset({
+    "-oN", "-oG", "-oX", "-oA", "--append-output",
+})
+
+# Flags that override data/script paths
+_PATH_OVERRIDE_FLAGS = frozenset({
+    "--datadir", "--script-updatedb", "--script-path", "--script-args-file",
+})
+
+_ALL_BLOCKED_FLAGS = _FILE_READ_FLAGS | _FILE_WRITE_FLAGS | _PATH_OVERRIDE_FLAGS
+
+# Safe pattern for --script arguments: bare script names, wildcards, categories
+# e.g. "default", "vuln,safe", "http-*", "smb-enum-shares"
+_SAFE_SCRIPT_NAME = re.compile(r"^[a-zA-Z0-9_*?,-]+$")
+
+# Shell metacharacters that should never appear in targets
+_SHELL_METACHAR = re.compile(r"[;|&`$(){}\[\]<>!#~]")
+
+
+class ValidationError(Exception):
+    """Raised when input validation fails."""
+
+
+def validate_options(options: str) -> list[str]:
+    """Validate and parse nmap options string.
+
+    Returns the parsed argument list on success. Raises ValidationError if
+    dangerous flags are detected.
+
+    Uses shlex.split() for proper quoted-argument handling.
+    """
+    try:
+        args = shlex.split(options)
+    except ValueError as e:
+        raise ValidationError(f"Malformed options string: {e}") from e
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+
+        # Normalize long flags that use = (e.g. --script=vuln)
+        flag = arg.split("=", 1)[0] if "=" in arg else arg
+
+        # Check against blocklist
+        if flag in _ALL_BLOCKED_FLAGS:
+            raise ValidationError(
+                f"Blocked flag: {flag} — this flag is not allowed for security reasons"
+            )
+
+        # Validate --script arguments
+        if flag == "--script":
+            if "=" in arg:
+                script_value = arg.split("=", 1)[1]
+            elif i + 1 < len(args):
+                script_value = args[i + 1]
+                i += 1
+            else:
+                raise ValidationError("--script requires an argument")
+
+            if not _SAFE_SCRIPT_NAME.match(script_value):
+                raise ValidationError(
+                    f"Blocked --script value: {script_value!r} — "
+                    f"only bare script names are allowed (no paths or URLs)"
+                )
+
+        i += 1
+
+    return args
+
+
+def validate_target(target: str) -> str:
+    """Validate a scan target string.
+
+    Allows IPs, hostnames, CIDR ranges. Blocks shell metacharacters and
+    path traversal. Returns the target unchanged on success.
+    """
+    if not target or not target.strip():
+        raise ValidationError("Target cannot be empty")
+
+    if ".." in target:
+        raise ValidationError(
+            f"Blocked target: {target!r} — path traversal not allowed"
+        )
+
+    if _SHELL_METACHAR.search(target):
+        raise ValidationError(
+            f"Blocked target: {target!r} — contains shell metacharacters"
+        )
+
+    # Block whitespace (could inject extra arguments)
+    if any(c.isspace() for c in target):
+        raise ValidationError(
+            f"Blocked target: {target!r} — whitespace not allowed in target"
+        )
+
+    return target
+
+
+def validate_save_to(save_to: str, project_root: Path) -> Path:
+    """Validate a save_to path is under engagement/evidence/.
+
+    Returns the resolved Path on success. Raises ValidationError if the
+    path escapes the evidence directory.
+    """
+    if not save_to:
+        raise ValidationError("save_to cannot be empty")
+
+    evidence_dir = (project_root / "engagement" / "evidence").resolve()
+    resolved = (project_root / save_to).resolve()
+
+    # Must be under engagement/evidence/
+    try:
+        resolved.relative_to(evidence_dir)
+    except ValueError:
+        raise ValidationError(
+            f"Blocked save_to: {save_to!r} — must be under engagement/evidence/"
+        )
+
+    return resolved
+
+
+def sanitize_target_for_filename(target: str) -> str:
+    """Sanitize a target string for use in evidence filenames.
+
+    Replaces slashes, dots-dots, and non-alphanumeric characters (except
+    dots, hyphens, and underscores) with underscores.
+    """
+    # First collapse any .. sequences
+    safe = target.replace("..", "_")
+    # Replace path separators
+    safe = safe.replace("/", "_").replace("\\", "_")
+    # Replace any remaining unsafe characters (keep alphanumeric, dot, hyphen, underscore)
+    safe = re.sub(r"[^a-zA-Z0-9._-]", "_", safe)
+    # Collapse multiple underscores
+    safe = re.sub(r"_+", "_", safe)
+    # Strip leading/trailing underscores
+    safe = safe.strip("_")
+    return safe or "unknown"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -84,6 +84,13 @@ if [[ -d "${MCP_NMAP_SERVER}/.venv" ]]; then
     mcp_cleaned=$((mcp_cleaned + 1))
 fi
 
+# nmap Docker image
+if command -v docker &>/dev/null && docker image inspect red-run-nmap:latest &>/dev/null 2>&1; then
+    docker rmi red-run-nmap:latest &>/dev/null
+    echo "  Removed Docker image: red-run-nmap:latest"
+    mcp_cleaned=$((mcp_cleaned + 1))
+fi
+
 # shell-server
 if [[ -d "${MCP_SHELL_SERVER}/.venv" ]]; then
     rm -rf "${MCP_SHELL_SERVER}/.venv"


### PR DESCRIPTION
## Summary
- Runs nmap inside a Docker container (`--network=host`, minimal capabilities) instead of `sudo nmap`, eliminating the passwordless sudo requirement
- Adds comprehensive input validation (`validate.py`) with flag blocklisting, target sanitization, and output flag protection before any input reaches subprocess
- Updates install/uninstall scripts to build the Docker image and manage cleanup

## Changes
- **`tools/nmap-server/server.py`** — Docker-based execution via `docker run`, replaces `sudo nmap` subprocess calls
- **`tools/nmap-server/validate.py`** — New input validation module: blocked flags, target format validation, dangerous option rejection
- **`tools/nmap-server/Dockerfile`** — Alpine-based nmap image (minimal attack surface)
- **`tools/nmap-server/tests/test_validate.py`** — 287-line test suite for validation logic
- **`install.sh` / `uninstall.sh`** — Docker image build on install, image removal on uninstall
- **`CLAUDE.md` / `README.md`** / agent docs — Updated to reflect Docker requirement

## Test plan
- [x] Unit tests pass for input validation (`test_validate.py`)
- [x] Existing server tests updated and passing (`test_server.py`)
- [x] Live scan tested against HTB target — correct results, evidence saved, no regressions


🤖 Generated with [Claude Code](https://claude.com/claude-code)