### PR TITLE
Document yolo mode as required for subagent execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 Claude Code skill library for penetration testing and CTF work.
 
+## Engagement Workflow
+
+**MANDATORY:** When the user mentions targets, attacking, scanning, pentesting,
+or references an existing engagement (resuming, continuing, next steps, status),
+invoke the `red-run-orchestrator` skill via the Skill tool IMMEDIATELY — before
+reading state, running tools, or generating any analysis. The orchestrator skill
+contains all routing logic, approval gates, and state management rules. Never
+manually call state-server MCP tools, run attack commands, or present engagement
+analysis from the main thread without the orchestrator skill loaded.
+
 ## Token Budget
 
 Every token costs money and latency. Consider token impact when making ANY
@@ -228,6 +238,15 @@ The MCP indexer builds embedding documents from these structured fields. `descri
 - **Discovery skill maintenance**: When creating a new technique skill, update the corresponding discovery skill's routing table to include it. `web-discovery` must route to every web technique skill.
 - **AD OPSEC: Kerberos-first authentication**: All AD skills default to Kerberos authentication via ccache to avoid NTLM-specific detections (Event 4776, CrowdStrike Identity Module PTH signatures). Each AD skill's Prerequisites section includes the `getTGT.py` → `KRB5CCNAME` → `-k -no-pass` workflow. All embedded tool commands use Kerberos auth flags: Impacket (`-k -no-pass`), NetExec (`--use-kcache`), Certipy (`-k`), bloodyAD (`-k`). Skills where Kerberos auth doesn't apply (relay, coercion, password spraying) explicitly state why and note the NTLM detection surface.
 - **Attackbox-first transfer**: Never download exploits, scripts, or tools directly to the target from the internet. Targets may lack outbound access, and operators must review files before execution on target. Workflow: (1) download/clone on attackbox, (2) review, (3) serve via `python3 -m http.server` or transfer with `scp`/`nc`/base64, (4) pull from target. Inline source code in heredocs is fine — the operator can read it in the skill.
+
+## Permission Mode
+
+red-run requires `--dangerously-skip-permissions` (yolo mode). Subagents work
+autonomously — running shell commands and MCP calls as part of each skill
+invocation. In regular permission mode, background agents cannot surface
+permission prompts to the operator; tool calls are silently denied and agents
+stall. The orchestrator's approval gates (operator confirms every routing
+decision before agent spawn) provide the human-in-the-loop control.
 
 ## Sandbox
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,13 @@ bash tools/state-viewer/generate-token.sh
 
 See `tools/state-viewer/README.md` for details.
 
-## Warning
+## Permission Mode
 
-`claude --dangerously-skip-permissions` (yolo mode) is available but **not recommended**. With it active, Claude will chain skills, pop shells, move laterally, and escalate privileges without pausing for confirmation. Avoid `--dangerously-skip-permissions` for maximum safety. You are responsible for containing Claude on your systems and for any legal consequences under the CFAA or equivalent legislation.
+red-run **requires** `claude --dangerously-skip-permissions` (yolo mode). Subagents work autonomously — running shell commands, MCP tool calls, and network operations as part of each skill invocation. In regular permission mode, background agents cannot surface permission prompts to the operator; tool calls are silently denied and agents stall.
+
+The orchestrator presents every routing decision for operator approval before spawning agents. You choose what to run — agents handle execution.
+
+red-run is a **proof of concept** tested only in CTF environments. Do not use it in production engagements. Run from an isolated VM or dedicated pentesting machine. You are responsible for containing Claude on your systems and for any legal consequences under the CFAA or equivalent legislation.
 
 ## Disclaimer
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,7 +192,7 @@ The tools that require elevated privileges are isolated behind MCP servers and D
 
 The pattern is consistent: if something needs elevated privilege, either it runs inside a container that has the specific capability, or the orchestrator stops and asks the operator to do it. Claude never runs `sudo` itself.
 
-This also means red-run works without adding Claude Code to sudoers, without `NOPASSWD` entries, and without `--dangerously-skip-permissions` for privilege escalation on the *host*. The attack surface is the target, not your machine.
+This also means red-run works without adding Claude Code to sudoers or `NOPASSWD` entries for privilege escalation on the *host*. The attack surface is the target, not your machine. Note that `--dangerously-skip-permissions` (yolo mode) is still **required** for subagent execution — see [Installation](installation.md).
 
 You can enforce this at the Claude Code level by adding `Bash(sudo *)` to the deny list in `~/.claude/settings.json`. This makes Claude Code refuse any Bash command starting with `sudo`, regardless of what an agent or skill tries to do:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -102,7 +102,7 @@ The MCP servers start automatically via `.mcp.json`. Give the orchestrator a tar
 
 > "Scan and attack 10.10.10.5"
 
-> **Yolo mode:** `claude --dangerously-skip-permissions` is available but **not recommended**. Claude may execute potentially dangerous commands without pausing for confirmation.
+> **Required:** Run with `claude --dangerously-skip-permissions` (yolo mode). Subagents work autonomously and cannot surface permission prompts in regular mode — tool calls are silently denied and agents stall. The orchestrator still requires operator approval before spawning each agent, but does not require approval for every agent tool invocation.
 
 ## Uninstall
 


### PR DESCRIPTION
## Summary
- Subagents work autonomously and cannot surface permission prompts in regular mode — tool calls are silently denied and agents stall
- Updated all references that previously advised against yolo mode (README, CLAUDE.md, docs/installation, docs/architecture)
- Added proof-of-concept/CTF-only notice to README
- Added CLAUDE.md "Engagement Workflow" section mandating orchestrator skill invocation before any manual state interaction

## Context
Discovered during a live engagement that background agents in regular permission mode get all Bash/MCP calls silently denied — prompts don't surface to the operator. Basic read-only commands (ps, date) pass but anything that does actual work is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)