### PR TITLE
feat: improve skill descriptions across 77 skills

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/ad/acl-abuse/SKILL.md
+++ b/skills/ad/acl-abuse/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: acl-abuse
-description: >
-  Exploits misconfigured Active Directory ACLs for privilege escalation.
-  Covers GenericAll, GenericWrite, WriteDACL, WriteOwner, ForceChangePassword,
-  targeted Kerberoasting via SPN manipulation, shadow credentials
-  (msDS-KeyCredentialLink → PKINIT), and AdminSDHolder persistence.
+description: "Exploits misconfigured Active Directory ACLs by abusing GenericAll, GenericWrite, WriteDACL, WriteOwner, ForceChangePassword, SPN-based targeted Kerberoasting, shadow credentials, and AdminSDHolder persistence. Use when BloodHound or manual enumeration reveals exploitable ACEs on user, group, or computer objects."
 keywords:
   - ACL abuse
   - ACE abuse

--- a/skills/ad/ad-discovery/SKILL.md
+++ b/skills/ad/ad-discovery/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: ad-discovery
-description: >
-  Enumerates Active Directory domains and maps attack surface for penetration
-  testing.
+description: "Enumerates Active Directory domains by collecting users, groups, computers, trusts, GPOs, ACLs, and attack paths via BloodHound, PowerView, and LDAP queries. Use when you have domain credentials or a foothold and need to map the AD attack surface before exploitation."
 keywords:
   - enumerate domain
   - AD recon

--- a/skills/ad/ad-persistence/SKILL.md
+++ b/skills/ad/ad-persistence/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: ad-persistence
-description: >
-  Establishes persistent access in Active Directory environments after domain
-  compromise. Covers DCShadow (rogue DC attribute modification), Skeleton Key
-  (LSASS master password), custom SSP injection (credential logging via
-  mimilib/memssp), security descriptor backdoors (WMI/WinRM/ DCOM/registry ACL
-  modification), ADFS Golden SAML (DKM key extraction and forged SAML tokens),
-  SID history persistence (DA SID in regular user), and certificate-based
-  persistence (golden certificate, renewal, enrollment agent).
+description: "Establishes persistent access in Active Directory via DCShadow, Skeleton Key, custom SSP injection, security descriptor backdoors, ADFS Golden SAML, SID history manipulation, and certificate-based persistence. Use when you have domain admin or equivalent privileges and need to maintain long-term access after domain compromise."
 keywords:
   - AD persistence
   - domain persistence

--- a/skills/ad/adcs-access-and-relay/SKILL.md
+++ b/skills/ad/adcs-access-and-relay/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: adcs-access-and-relay
-description: >
-  Exploits ADCS through ACL abuse on templates/CA objects and NTLM relay to
-  enrollment endpoints. Covers ESC4 (template ACL → modify to ESC1), ESC5 (PKI
-  object ACLs), ESC7 (ManageCA/ManageCertificates abuse), ESC8 (NTLM relay to
-  HTTP enrollment), ESC11 (NTLM relay to ICPR RPC).
+description: "Exploits AD CS enrollment endpoints and PKI object ACLs via ESC4 template modification, ESC5 PKI object abuse, ESC7 ManageCA/ManageCertificates escalation, ESC8 NTLM relay to HTTP enrollment, and ESC11 NTLM relay to ICPR RPC. Use when Certipy or Certify identifies vulnerable CA configurations, writable template ACLs, or unauthenticated enrollment endpoints."
 keywords:
   - ESC4
   - ESC5

--- a/skills/ad/adcs-persistence/SKILL.md
+++ b/skills/ad/adcs-persistence/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: adcs-persistence
-description: >
-  Establishes persistence and exploits weak certificate mapping in AD CS.
-  Covers ESC9 (no security extension), ESC10 (weak certificate mapping),
-  ESC12-15 (YubiHSM, issuance policy, altSecIdentities, application policies),
-  Golden Certificate (forge with stolen CA key), certificate theft
-  (DPAPI/CAPI/CNG), and account persistence via certificate mapping.
+description: "Establishes AD CS persistence and exploits weak certificate mapping via ESC9-ESC15, Golden Certificate forgery with stolen CA keys, certificate theft from DPAPI/CAPI/CNG stores, and account persistence through certificate mapping. Use when you have CA-level access or need to maintain persistence through certificate-based authentication."
 keywords:
   - ESC9
   - ESC10

--- a/skills/ad/adcs-template-abuse/SKILL.md
+++ b/skills/ad/adcs-template-abuse/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: adcs-template-abuse
-description: >
-  Exploits misconfigured AD CS certificate templates to impersonate any domain
-  user via SAN manipulation or enrollment agent abuse. Covers ESC1 (enrollee
-  supplies subject), ESC2 (any-purpose/no EKU), ESC3 (enrollment agent), ESC6
-  (EDITF_ATTRIBUTESUBJECTALTNAME2 CA flag).
+description: "Exploits misconfigured AD CS certificate templates to impersonate any domain user via ESC1 enrollee-supplied SAN, ESC2 any-purpose/no-EKU templates, ESC3 enrollment agent abuse, and ESC6 EDITF_ATTRIBUTESUBJECTALTNAME2 CA flag exploitation. Use when Certipy or Certify finds templates with enrollee-controlled SANs, overly permissive EKUs, or enrollment agent configurations."
 keywords:
   - ESC1
   - ESC2

--- a/skills/ad/auth-coercion-relay/SKILL.md
+++ b/skills/ad/auth-coercion-relay/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: auth-coercion-relay
-description: >
-  Forces remote systems to authenticate back to attacker-controlled listeners
-  and relays captured authentication to escalate privileges or move laterally.
-  Covers authentication coercion (PetitPotam, PrinterBug, DFSCoerce,
-  ShadowCoerce, CheeseOunce), NTLM relay (ntlmrelayx to LDAP/SMB/AD CS/MSSQL),
-  Kerberos relay (krbrelayx, mitm6), and name resolution poisoning
-  (LLMNR/NBNS/WPAD via Responder).
+description: "Coerces remote systems into authenticating to attacker-controlled listeners via PetitPotam, PrinterBug, DFSCoerce, ShadowCoerce, and CheeseOunce, then relays captured NTLM/Kerberos authentication to LDAP, SMB, AD CS, or MSSQL endpoints. Use when you need to escalate privileges or move laterally by exploiting coercible services and relay-vulnerable endpoints."
 keywords:
   - petitpotam
   - printerbug

--- a/skills/ad/credential-dumping/SKILL.md
+++ b/skills/ad/credential-dumping/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: credential-dumping
-description: >
-  Extracts credentials from Active Directory: DCSync replication, NTDS.dit
-  database extraction, SAM hive dump, Azure AD Connect (ADSync) credential
-  extraction, LAPS passwords (legacy + Windows LAPS), gMSA passwords (KDS
-  root key + GoldenGMSA), dMSA exploitation (BadSuccessor CVE-2025-21293),
-  and DSRM credentials.
+description: "Extracts credentials from Active Directory via DCSync replication, NTDS.dit extraction, SAM hive dumps, Azure AD Connect secrets, LAPS/gMSA/dMSA password retrieval, and DSRM credential recovery. Use when you have domain admin, replication rights, or delegated access to credential stores and need to harvest hashes or plaintext passwords."
 keywords:
   - DCSync
   - secretsdump

--- a/skills/ad/gpo-abuse/SKILL.md
+++ b/skills/ad/gpo-abuse/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: gpo-abuse
-description: >
-  Exploits Group Policy Objects for code execution, privilege escalation, and
-  lateral movement in Active Directory. Covers GPO enumeration (GPOHound,
-  BloodHound, PowerView), exploitation via immediate tasks, logon scripts, and
-  registry modifications (SharpGPOAbuse, PowerGPOAbuse, pyGPOAbuse,
-  GroupPolicyBackdoor), SYSVOL/NETLOGON logon script poisoning, and GPP
-  password extraction.
+description: "Exploits writable Group Policy Objects for code execution, privilege escalation, and lateral movement via immediate tasks, logon scripts, registry modifications, SYSVOL/NETLOGON script poisoning, and GPP password extraction. Use when BloodHound or GPOHound identifies writable GPOs linked to high-value OUs or when GPP credentials exist in SYSVOL."
 keywords:
   - GPO abuse
   - group policy

--- a/skills/ad/kerberos-delegation/SKILL.md
+++ b/skills/ad/kerberos-delegation/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: kerberos-delegation
-description: >
-  Exploits Kerberos delegation misconfigurations for privilege escalation and
-  lateral movement in Active Directory. Covers Unconstrained Delegation (TGT
-  harvesting via coercion), Constrained Delegation (S4U2Self + S4U2Proxy with
-  SPN swapping), and Resource-Based Constrained Delegation (RBCD via writable
-  machine accounts).
+description: "Exploits Kerberos delegation misconfigurations including Unconstrained Delegation TGT harvesting, Constrained Delegation S4U2Self/S4U2Proxy with SPN swapping, and Resource-Based Constrained Delegation via writable machine accounts. Use when enumeration reveals accounts with delegation flags set or when you can write msDS-AllowedToActOnBehalfOfOtherIdentity on a target computer."
 keywords:
   - delegation
   - unconstrained delegation

--- a/skills/ad/kerberos-roasting/SKILL.md
+++ b/skills/ad/kerberos-roasting/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: kerberos-roasting
-description: >
-  Extracts and cracks Kerberos service tickets (Kerberoasting) and AS-REP
-  hashes (AS-REP Roasting) for offline password recovery.
+description: "Requests Kerberos service tickets for SPN-enabled accounts and AS-REP hashes for accounts without pre-authentication, then cracks them offline for password recovery. Use when you have domain credentials and want to target service accounts or accounts with DONT_REQ_PREAUTH set."
 keywords:
   - kerberoast
   - kerberoasting

--- a/skills/ad/kerberos-ticket-forging/SKILL.md
+++ b/skills/ad/kerberos-ticket-forging/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: kerberos-ticket-forging
-description: >
-  Forges Kerberos tickets for domain persistence and privilege escalation.
-  Covers Golden Ticket (krbtgt hash → forged TGT), Silver Ticket (service hash
-  → forged TGS), Diamond Ticket (decrypt/modify/re-encrypt legitimate TGT for
-  stealth), Sapphire Ticket (U2U PAC swap), and Pass-the-Ticket injection.
+description: "Forges Kerberos tickets for domain persistence and privilege escalation using Golden Ticket, Silver Ticket, Diamond Ticket, Sapphire Ticket, and Pass-the-Ticket techniques. Use when you have the krbtgt hash, service account hash, or AES keys and need to forge TGTs/TGS for impersonation or stealth persistence."
 keywords:
   - golden ticket
   - silver ticket

--- a/skills/ad/pass-the-hash/SKILL.md
+++ b/skills/ad/pass-the-hash/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: pass-the-hash
-description: >
-  Authenticates to AD services using NTLM hashes, AES keys, or Kerberos
-  tickets without cracking passwords. Covers Pass-the-Hash,
-  Over-Pass-the-Hash, Pass-the-Key, and Pass-the-Ticket for lateral movement.
+description: "Authenticates to AD services using NTLM hashes, AES keys, or Kerberos tickets without cracking passwords via Pass-the-Hash, Over-Pass-the-Hash, Pass-the-Key, and Pass-the-Ticket techniques. Use when you have harvested credential material and need to move laterally or access services without knowing the plaintext password."
 keywords:
   - pass the hash
   - PTH

--- a/skills/ad/sccm-exploitation/SKILL.md
+++ b/skills/ad/sccm-exploitation/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: sccm-exploitation
-description: >
-  Enumerates and exploits Microsoft SCCM/MECM (System Center Configuration
-  Manager / Microsoft Endpoint Configuration Manager) infrastructure for
-  credential harvesting, lateral movement, and domain escalation. Covers SCCM
-  enumeration (sccmhunter, SharpSCCM), Network Access Account (NAA) credential
-  extraction (policy request, WMI DPAPI, WMI repository), management point
-  NTLM relay to MSSQL (TAKEOVER1), client push relay (ELEVATE2), PXE boot
-  media credential harvesting (CRED1), SCCM database credential extraction,
-  application deployment for lateral movement, and SCCM share looting.
+description: "Enumerates and exploits SCCM/MECM infrastructure for credential harvesting, lateral movement, and domain escalation via NAA credential extraction, management point relay, client push relay, PXE boot harvesting, and application deployment abuse. Use when SCCM/MECM infrastructure is discovered in the environment and you need to extract NAA credentials, relay to site databases, or leverage deployment mechanisms."
 keywords:
   - SCCM
   - MECM

--- a/skills/ad/trust-attacks/SKILL.md
+++ b/skills/ad/trust-attacks/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: trust-attacks
-description: >
-  Enumerates Active Directory trust relationships and exploits them for
-  cross-domain and cross-forest privilege escalation. Covers trust enumeration
-  (nltest, PowerView, BloodHound), SID history injection (child domain to
-  forest root via golden/diamond ticket with extra SIDs), inter-realm TGT
-  forging using trust keys, TGT delegation coercion capture (Rubeus monitor +
-  SpoolSample/DFSCoerce across forest trusts with ENABLE_TGT_DELEGATION),
-  cross-forest trust abuse (SID filtering bypass, RBCD, Kerberoasting via
-  trust account), and PAM trust exploitation (shadow principals in bastion
-  forests).
+description: "Enumerates AD trust relationships and exploits them for cross-domain and cross-forest privilege escalation via SID history injection, inter-realm TGT forging, TGT delegation coercion, SID filtering bypass, cross-forest RBCD/Kerberoasting, and PAM trust exploitation. Use when you have compromised a child domain and need to escalate to the forest root, or when cross-forest trusts are present and exploitable."
 keywords:
   - trust attacks
   - domain trust

--- a/skills/credential/password-spraying/SKILL.md
+++ b/skills/credential/password-spraying/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: password-spraying
-description: >
-  Performs password spraying against authentication services with lockout-safe
-  techniques. Works against AD (SMB/Kerberos/LDAP), SSH, web login forms, OWA,
-  and any service with username/password auth. Service-agnostic — the
-  orchestrator passes target services and spray intensity tier.
+description: "Performs lockout-safe password spraying against AD (SMB/Kerberos/LDAP), SSH, web login forms, OWA, and other username/password services. Use when valid usernames are available and you need to test common or known passwords across multiple accounts."
 keywords:
   - password spray
   - spray passwords

--- a/skills/evasion/av-edr-evasion/SKILL.md
+++ b/skills/evasion/av-edr-evasion/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: av-edr-evasion
-description: >
-  Bypass antivirus and EDR detection for payload delivery during exploitation.
-  Covers custom payload compilation (mingw C, Go), AMSI bypass, shellcode
-  alternatives, and ETW patching. Route here when an agent reports a payload
-  was quarantined, blocked, or detected by endpoint protection.
+description: "Compiles custom payloads (mingw C, Go), patches AMSI and ETW, encodes shellcode, and applies obfuscation to bypass antivirus and EDR detection. Use when a payload is quarantined, blocked, or detected by endpoint protection during exploitation."
 keywords:
   - AMSI bypass
   - antivirus evasion

--- a/skills/network/container-escapes/SKILL.md
+++ b/skills/network/container-escapes/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: container-escapes
-description: >
-  Container escape, Docker breakout, and Kubernetes exploitation.
+description: "Escapes Docker containers via socket mounts, privileged mode, and kernel exploits, and exploits Kubernetes misconfigurations including pod escapes and service account abuse. Use when you have a shell inside a container or pod and need to reach the host or cluster resources."
 keywords:
   - container escape
   - docker breakout

--- a/skills/network/database-enumeration/SKILL.md
+++ b/skills/network/database-enumeration/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: database-enumeration
-description: >
-  Database service enumeration and quick-win access checks for MSSQL,
-  MySQL, PostgreSQL, Oracle, MongoDB, and Redis. Checks default/empty
-  passwords, unauthenticated access, and command execution capabilities.
-  Use after network-recon identifies database ports.
+description: "Enumerates MSSQL, MySQL, PostgreSQL, Oracle, MongoDB, and Redis services by checking default/empty passwords, unauthenticated access, and command execution capabilities. Use after network-recon identifies database ports."
 keywords:
   - MSSQL
   - MySQL

--- a/skills/network/infrastructure-enumeration/SKILL.md
+++ b/skills/network/infrastructure-enumeration/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: infrastructure-enumeration
-description: >
-  Enumeration of infrastructure services: DNS, SMTP, SNMP, IPMI, NFS,
-  TFTP, RPC/MSRPC, and HTTP/HTTPS surface detection. Checks zone
-  transfers, open relays, default community strings, cipher zero, NFS
-  exports, and web technology fingerprinting. Use after network-recon
-  identifies infrastructure ports.
+description: "Enumerates DNS, SMTP, SNMP, IPMI, NFS, TFTP, RPC/MSRPC, and HTTP/HTTPS services by checking zone transfers, open relays, default community strings, cipher zero, NFS exports, and web technology fingerprints. Use after network-recon identifies infrastructure ports."
 keywords:
   - DNS zone transfer
   - SMTP relay

--- a/skills/network/network-recon/SKILL.md
+++ b/skills/network/network-recon/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: network-recon
-description: >
-  Network reconnaissance, host discovery, port scanning, and OS
-  fingerprinting. Produces a port/service map that the orchestrator uses
-  to route to service-specific enumeration skills.
+description: "Performs host discovery, port scanning, and OS fingerprinting to produce a port/service map for the target network. Use when starting an engagement or when new subnets are discovered and need initial reconnaissance."
 keywords:
   - scan this network
   - nmap

--- a/skills/network/pivoting-tunneling/SKILL.md
+++ b/skills/network/pivoting-tunneling/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: pivoting-tunneling
-description: >
-  Network pivoting, port forwarding, and tunneling through compromised hosts
-  to reach internal networks.
+description: "Sets up SOCKS proxies, SSH tunnels, port forwards, and tool-based tunnels (ligolo, chisel, sshuttle) through compromised hosts to reach internal networks. Use when you have a foothold and need to route traffic to unreachable subnets or services."
 keywords:
   - pivot
   - tunnel

--- a/skills/network/remote-access-enumeration/SKILL.md
+++ b/skills/network/remote-access-enumeration/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: remote-access-enumeration
-description: >
-  Enumeration of remote access services: FTP, SSH, RDP, VNC, and WinRM.
-  Checks anonymous access, default credentials, version vulnerabilities,
-  and authentication methods. Use after network-recon identifies remote
-  access ports.
+description: "Enumerates FTP, SSH, RDP, VNC, and WinRM services by checking anonymous access, default credentials, version vulnerabilities, and authentication methods. Use after network-recon identifies remote access ports."
 keywords:
   - FTP anonymous
   - SSH version

--- a/skills/network/smb-enumeration/SKILL.md
+++ b/skills/network/smb-enumeration/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: smb-enumeration
-description: >
-  SMB share enumeration, access testing, password policy extraction, and
-  content searching. Enumerates shares via null session, guest, and
-  authenticated access. Covers share listing, per-share access testing,
-  MANSPIDER content search, and SMB vulnerability detection (signing,
-  EternalBlue). Use after network-recon identifies SMB ports (139/445).
+description: "Enumerates SMB shares via null session, guest, and authenticated access, tests per-share permissions, extracts password policies, searches share content with MANSPIDER, and detects SMB vulnerabilities (signing, EternalBlue). Use after network-recon identifies SMB ports (139/445)."
 keywords:
   - SMB shares
   - null session

--- a/skills/network/smb-exploitation/SKILL.md
+++ b/skills/network/smb-exploitation/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: smb-exploitation
-description: >
-  Exploit remote SMB vulnerabilities for unauthenticated code execution on
-  Windows hosts.
+description: "Exploits remote SMB vulnerabilities (MS08-067, MS17-010/EternalBlue, SMBGhost/CVE-2020-0796) for unauthenticated code execution on Windows hosts. Use when SMB enumeration reveals a vulnerable SMB version or missing patches on ports 139/445."
 keywords:
   - MS08-067
   - MS17-010

--- a/skills/network/xmpp-enumeration/SKILL.md
+++ b/skills/network/xmpp-enumeration/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: xmpp-enumeration
-description: >
-  XMPP/Jabber service enumeration for Openfire, ejabberd, Prosody, and other
-  XMPP servers. Trigger when ports 5222 (client), 5223 (legacy TLS), or 5269
-  (server-to-server) are found open. Covers authentication testing, user
-  enumeration, MUC room discovery, and server fingerprinting. Do NOT use for
-  AD enumeration or credential spraying — route those to the appropriate skills.
+description: "Enumerates XMPP/Jabber servers (Openfire, ejabberd, Prosody) by testing authentication, enumerating users, discovering MUC rooms, and fingerprinting server versions. Use when ports 5222, 5223, or 5269 are found open."
 keywords:
   - xmpp
   - jabber

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -1,19 +1,6 @@
 ---
 name: orchestrator
-description: >
-  USE THIS SKILL when the user provides a target or list of targets (IPs,
-  hostnames, URLs, subnets) and asks to attack, pentest, hack, scan, assess,
-  or test them. ALSO USE THIS SKILL when the user references an existing
-  engagement — resuming, continuing, picking up, checking status, or asking
-  about next steps. Trigger phrases: "attack X", "pentest X", "hack X",
-  "scan X", "start testing X", "pop X", "CTF target X", "engage X",
-  "these targets", "resume engagement", "pick it up", "continue testing",
-  "next steps", "where were we", "resuming", "advise next steps",
-  "what should we do next", "engagement status".
-  This is the entry point for all multi-phase penetration tests — handles
-  recon, attack surface mapping, vulnerability chaining, and routes to
-  technique skills for exploitation. Do NOT use when the user names a specific
-  single technique (e.g., "run kerberoasting against X").
+description: "Entry point for multi-phase penetration tests that handles recon, attack surface mapping, vulnerability chaining, and routes to technique-specific skills for exploitation. Use when the user provides targets (IPs, hostnames, URLs, subnets) and asks to attack, pentest, scan, or assess them, or when resuming an existing engagement."
 keywords:
   - pentest this target
   - start an engagement

--- a/skills/post-exploit/credential-cracking/SKILL.md
+++ b/skills/post-exploit/credential-cracking/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: credential-cracking
-description: >
-  Offline credential and file cracking with hashcat and john. Use when any skill
-  recovers hashes (NTLM, Kerberos TGS/AS-REP, shadow, MSCACHE2) or encrypted
-  files (ZIP, Office, PDF, KeePass, SSH key, 7z, RAR). Trigger phrases: "crack
-  this hash", "brute force the password", "offline crack", "john", "hashcat",
-  "zip2john", "password-protected file". Do NOT use for online password attacks
-  (spraying, brute force against services) — use password-spraying instead.
+description: "Cracks hashes (NTLM, Kerberos TGS/AS-REP, shadow, MSCACHE2) and encrypted files (ZIP, Office, PDF, KeePass, SSH key, 7z, RAR) offline using hashcat and john. Use when any skill recovers password hashes or encounters password-protected files that need offline brute-force or dictionary attacks."
 keywords:
   - crack
   - hash

--- a/skills/privesc/linux-cron-service-abuse/SKILL.md
+++ b/skills/privesc/linux-cron-service-abuse/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: linux-cron-service-abuse
-description: >
-  Exploit cron jobs, systemd timers/services, D-Bus services, and Unix sockets
-  for privilege escalation.
+description: "Exploits writable cron jobs, wildcard injections, systemd timer/service misconfigurations, D-Bus policy weaknesses, and Unix socket permissions for privilege escalation. Use when pspy or enumeration reveals root-owned scheduled tasks, writable service files, or exploitable D-Bus interfaces."
 keywords:
   - cron privesc
   - wildcard injection

--- a/skills/privesc/linux-discovery/SKILL.md
+++ b/skills/privesc/linux-discovery/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: linux-discovery
-description: >
-  Linux local privilege escalation enumeration and attack surface mapping.
+description: "Runs LinPEAS, LinEnum, and pspy to enumerate sudo rules, SUID binaries, capabilities, cron jobs, writable paths, kernel version, and running processes for privilege escalation vectors. Use when you have a low-privilege shell on a Linux host and need to identify escalation paths."
 keywords:
   - enumerate linux privesc
   - check for privilege escalation

--- a/skills/privesc/linux-file-path-abuse/SKILL.md
+++ b/skills/privesc/linux-file-path-abuse/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: linux-file-path-abuse
-description: >
-  Exploit writable critical files, NFS misconfigurations, shared library
-  hijacking, and privileged group membership (docker, lxd, disk, adm, video,
-  staff) for Linux privilege escalation. Use when a user belongs to a
-  privileged group or has write access to sensitive files or paths.
+description: "Exploits writable critical files (/etc/passwd, /etc/shadow), NFS no_root_squash, shared library hijacking (ld.so.conf, rpath), and privileged group membership (docker, lxd, disk, adm) for Linux privilege escalation. Use when a user belongs to a privileged group or has write access to sensitive files or paths."
 keywords:
   - writable passwd
   - nfs privesc

--- a/skills/privesc/linux-kernel-exploits/SKILL.md
+++ b/skills/privesc/linux-kernel-exploits/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: linux-kernel-exploits
-description: >
-  Exploit Linux kernel vulnerabilities and escape restricted shells for
-  privilege escalation.
+description: "Exploits Linux kernel vulnerabilities (DirtyPipe, DirtyCow, GameOverlay, nf_tables UAF) and escapes restricted shells (rbash, rksh) for privilege escalation to root. Use when the kernel version is outdated or linux-exploit-suggester identifies a viable CVE, or when trapped in a restricted shell."
 keywords:
   - kernel exploit
   - dirtypipe

--- a/skills/privesc/linux-sudo-suid-capabilities/SKILL.md
+++ b/skills/privesc/linux-sudo-suid-capabilities/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: linux-sudo-suid-capabilities
-description: >
-  Exploit sudo misconfigurations, SUID/SGID binaries, and Linux capabilities
-  for privilege escalation.
+description: "Exploits sudo misconfigurations (NOPASSWD, LD_PRELOAD, env_keep), SUID/SGID binaries via GTFOBins techniques, and Linux capabilities (cap_setuid, cap_dac_override) for privilege escalation. Use when sudo -l, find -perm, or getcap reveals exploitable binaries or permissions."
 keywords:
   - exploit sudo
   - abuse suid

--- a/skills/privesc/windows-credential-harvesting/SKILL.md
+++ b/skills/privesc/windows-credential-harvesting/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: windows-credential-harvesting
-description: >
-  Harvest stored credentials from a Windows system for privilege escalation or
-  lateral movement.
+description: "Extracts stored credentials from DPAPI vaults, registry (autologon, VNC, putty), browser password stores, unattend.xml, SAM/SYSTEM hives, and cmdkey saved entries on Windows systems. Use when you have local access and need credentials for privilege escalation or lateral movement."
 keywords:
   - credential harvesting
   - DPAPI

--- a/skills/privesc/windows-discovery/SKILL.md
+++ b/skills/privesc/windows-discovery/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: windows-discovery
-description: >
-  Windows local privilege escalation enumeration and attack surface mapping.
+description: "Runs WinPEAS, PowerUp, Seatbelt, and WES-NG to enumerate services, scheduled tasks, token privileges, missing patches, registry keys, and installed software for privilege escalation vectors. Use when you have a low-privilege shell on a Windows host and need to identify escalation paths."
 keywords:
   - enumerate privesc
   - check for privilege escalation

--- a/skills/privesc/windows-kernel-exploits/SKILL.md
+++ b/skills/privesc/windows-kernel-exploits/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: windows-kernel-exploits
-description: >
-  Exploit Windows kernel vulnerabilities, vulnerable drivers, and privileged
-  file operations for local privilege escalation to SYSTEM.
+description: "Exploits Windows kernel vulnerabilities, BYOVD (bring your own vulnerable driver), PrintNightmare local, named pipe impersonation, and privileged file write primitives for escalation to SYSTEM. Use when WES-NG or Watson identifies missing patches, or when exploit suggester flags a kernel CVE."
 keywords:
   - kernel exploit
   - exploit suggester

--- a/skills/privesc/windows-service-dll-abuse/SKILL.md
+++ b/skills/privesc/windows-service-dll-abuse/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: windows-service-dll-abuse
-description: >
-  Exploit Windows service misconfigurations and DLL hijacking for local
-  privilege escalation.
+description: "Exploits unquoted service paths, writable service binaries (binpath replacement), weak service DACLs, and DLL search-order hijacking for local privilege escalation on Windows. Use when PowerUp or accesschk reveals misconfigured services or writable directories in the DLL search path."
 keywords:
   - unquoted service path
   - dll hijacking

--- a/skills/privesc/windows-token-impersonation/SKILL.md
+++ b/skills/privesc/windows-token-impersonation/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: windows-token-impersonation
-description: >
-  Exploit Windows token privileges for local privilege escalation to SYSTEM.
+description: "Exploits SeImpersonatePrivilege and SeDebugPrivilege using potato attacks (JuicyPotato, PrintSpoofer, GodPotato, RoguePotato) and token manipulation for escalation to SYSTEM. Use when whoami /priv shows SeImpersonate, SeAssignPrimaryToken, or SeDebug on a service account."
 keywords:
   - potato exploit
   - juicypotato

--- a/skills/privesc/windows-uac-bypass/SKILL.md
+++ b/skills/privesc/windows-uac-bypass/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: windows-uac-bypass
-description: >
-  Bypass Windows User Account Control to escalate from medium to high
-  integrity.
+description: "Bypasses Windows UAC using fodhelper, eventvwr, silentcleanup, COM hijacking, and auto-elevate binary abuse to escalate from medium to high integrity. Use when you have a local admin account but are running at medium integrity and need high-integrity or elevated access."
 keywords:
   - bypass UAC
   - UAC bypass

--- a/skills/research/unknown-vector-analysis/SKILL.md
+++ b/skills/research/unknown-vector-analysis/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: unknown-vector-analysis
-description: >
-  Analyze custom applications, scripts, and binaries that standard technique
-  skills could not exploit. Performs source code review, attack surface mapping,
-  CVE research, and PoC adaptation. Route here when ANY technique agent returns
-  saying standard patterns do not match, the target uses a custom/unknown
-  application, or no existing technique skill covers the vector. Trigger
-  phrases: "standard patterns don't match", "custom script", "unknown binary",
-  "no matching technique", "unrecognized application". Do NOT use for known
-  vulnerability classes that have dedicated technique skills — route to those
-  instead.
+description: "Performs source code review, binary analysis, attack surface mapping, CVE research, and PoC adaptation for custom applications, scripts, and binaries that standard technique skills cannot exploit. Use when technique agents report that standard patterns do not match or the target uses a custom/unknown application."
 keywords:
   - custom application
   - unknown binary

--- a/skills/retrospective/SKILL.md
+++ b/skills/retrospective/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: retrospective
-description: >
-  Post-engagement lessons-learned retrospective. Reads the engagement
-  directory, analyzes skill routing decisions, identifies knowledge gaps and
-  missing skills, and produces an actionable improvement report.
+description: "Reads the engagement directory, analyzes skill routing decisions, identifies knowledge gaps and missing skills, and produces an actionable improvement report. Use after an engagement completes to generate a lessons-learned retrospective."
 keywords:
   - what went wrong
   - what worked

--- a/skills/web/2fa-bypass/SKILL.md
+++ b/skills/web/2fa-bypass/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: 2fa-bypass
-description: >
-  Bypass two-factor authentication (2FA/MFA) during authorized penetration
-  testing.
+description: "Bypass two-factor authentication by brute-forcing OTP codes, exploiting backup code weaknesses, manipulating step-up authentication flows, and abusing session token reuse. Use when a login form presents 2FA/MFA after valid credentials are obtained."
 keywords:
   - 2fa bypass
   - mfa bypass

--- a/skills/web/ajp-ghostcat/SKILL.md
+++ b/skills/web/ajp-ghostcat/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: ajp-ghostcat
-description: >
-  Exploit Apache JServ Protocol (AJP) misconfigurations and Ghostcat
-  (CVE-2020-1938) for file read and remote code execution on Apache Tomcat.
-  Use when port 8009 is open or AJP connector is exposed.
+description: "Exploit Apache JServ Protocol (AJP) misconfigurations and Ghostcat (CVE-2020-1938) for file read and remote code execution on Apache Tomcat. Use when port 8009 is open or AJP connector is exposed."
 keywords:
   - AJP
   - Apache JServ Protocol

--- a/skills/web/browser-exploitation/SKILL.md
+++ b/skills/web/browser-exploitation/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: browser-exploitation
-description: >
-  Exploit browser-based attack surfaces: malicious extension crafting for bot
-  interaction scenarios, Chrome DevTools Protocol abuse on exposed debug ports,
-  and browser profile/cache data extraction from compromised hosts.
+description: "Craft malicious browser extensions, abuse Chrome DevTools Protocol on exposed debug ports, and extract credentials from browser profile and cache data. Use when targeting browser-based attack surfaces including bot interaction scenarios or compromised hosts with browser installations."
 keywords:
   - chrome extension
   - firefox extension

--- a/skills/web/command-injection/SKILL.md
+++ b/skills/web/command-injection/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: command-injection
-description: >
-  Guide OS command injection exploitation during authorized penetration
-  testing.
+description: "Inject OS commands through shell metacharacters, backticks, pipes, and subshells in web application parameters that pass user input to system(), exec(), or similar functions. Use when user-controlled input is concatenated into shell commands on the server."
 keywords:
   - command injection
   - OS injection

--- a/skills/web/cors-misconfiguration/SKILL.md
+++ b/skills/web/cors-misconfiguration/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: cors-misconfiguration
-description: >
-  Exploit CORS (Cross-Origin Resource Sharing) misconfigurations during
-  authorized penetration testing.
+description: "Exploit CORS misconfigurations including reflected origins, null origin trusts, wildcard with credentials, and subdomain-based bypasses to exfiltrate sensitive data cross-origin. Use when Access-Control-Allow-Origin headers reflect attacker-controlled origins or accept null."
 keywords:
   - cors
   - cors misconfiguration

--- a/skills/web/csrf/SKILL.md
+++ b/skills/web/csrf/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: csrf
-description: >
-  Exploit Cross-Site Request Forgery (CSRF) vulnerabilities during authorized
-  penetration testing.
+description: "Forge cross-site requests to perform state-changing actions by bypassing anti-CSRF tokens, SameSite cookie restrictions, and content-type validations. Use when a state-changing endpoint lacks proper CSRF protections or when existing protections can be circumvented."
 keywords:
   - csrf
   - cross-site request forgery

--- a/skills/web/deserialization-dotnet/SKILL.md
+++ b/skills/web/deserialization-dotnet/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: deserialization-dotnet
-description: >
-  Exploit .NET deserialization vulnerabilities during authorized penetration
-  testing.
+description: "Exploit .NET deserialization via BinaryFormatter, ViewState, JSON.NET TypeNameHandling, and SoapFormatter gadget chains using ysoserial.net payloads. Use when the target accepts serialized .NET objects, encrypted ViewState with known machine keys, or JSON with type metadata."
 keywords:
   - .net deserialization
   - ysoserial.net

--- a/skills/web/deserialization-java/SKILL.md
+++ b/skills/web/deserialization-java/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: deserialization-java
-description: >
-  Exploit Java deserialization vulnerabilities during authorized penetration
-  testing.
+description: "Exploit Java deserialization via ysoserial gadget chains (CommonsCollections, JNDI injection, Log4Shell) targeting T3, IIOP, HTTP, and JMX endpoints. Use when the target accepts serialized Java objects or JNDI lookups in user-controlled input."
 keywords:
   - java deserialization
   - ysoserial

--- a/skills/web/deserialization-php/SKILL.md
+++ b/skills/web/deserialization-php/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: deserialization-php
-description: >
-  Exploit PHP deserialization vulnerabilities during authorized penetration
-  testing.
+description: "Exploit PHP object injection via unserialize() and phar:// deserialization using PHPGGC gadget chains targeting __wakeup, __destruct, and __toString magic methods. Use when user input reaches unserialize() or phar stream wrappers in PHP applications."
 keywords:
   - php deserialization
   - php object injection

--- a/skills/web/file-upload-bypass/SKILL.md
+++ b/skills/web/file-upload-bypass/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: file-upload-bypass
-description: >
-  Guide file upload restriction bypass during authorized penetration testing.
+description: "Bypass file upload restrictions using extension manipulation, content-type spoofing, magic byte prepending, double extensions, and null byte injections to upload webshells. Use when the application has a file upload feature with client-side or server-side filtering."
 keywords:
   - file upload bypass
   - upload shell

--- a/skills/web/idor/SKILL.md
+++ b/skills/web/idor/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: idor
-description: >
-  Exploit Insecure Direct Object Reference (IDOR) and broken access control
-  vulnerabilities during authorized penetration testing.
+description: "Enumerate and tamper with object references (numeric IDs, UUIDs, encoded values) in API parameters, URLs, and request bodies to access unauthorized resources. Use when endpoints expose direct object references without proper authorization checks."
 keywords:
   - idor
   - idor enumeration

--- a/skills/web/jwt-attacks/SKILL.md
+++ b/skills/web/jwt-attacks/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: jwt-attacks
-description: >
-  Exploit JWT (JSON Web Token) vulnerabilities during authorized penetration
-  testing.
+description: "Forge and manipulate JSON Web Tokens via algorithm confusion (RS256-to-HS256), alg:none bypass, kid injection, JWK/JKU spoofing, and weak secret brute-forcing. Use when the application uses JWTs for authentication or session management."
 keywords:
   - JWT attack
   - JWT bypass

--- a/skills/web/ldap-injection/SKILL.md
+++ b/skills/web/ldap-injection/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: ldap-injection
-description: >
-  Exploit LDAP injection vulnerabilities during authorized penetration
-  testing.
+description: "Inject LDAP filter syntax to bypass authentication, extract directory attributes, and enumerate users via wildcard and blind injection techniques. Use when user input is concatenated into LDAP search filters or bind operations."
 keywords:
   - ldap injection
   - ldap filter injection

--- a/skills/web/lfi/SKILL.md
+++ b/skills/web/lfi/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: lfi
-description: >
-  Guide Local File Inclusion (LFI) and Remote File Inclusion (RFI)
-  exploitation during authorized penetration testing.
+description: "Read arbitrary server files and achieve code execution via path traversal, PHP wrappers (php://filter, php://input, data://), log poisoning, and remote file inclusion. Use when a parameter controls a file path used in include(), require(), or similar file operations."
 keywords:
   - LFI
   - lfi

--- a/skills/web/nosql-injection/SKILL.md
+++ b/skills/web/nosql-injection/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: nosql-injection
-description: >
-  Guide NoSQL injection exploitation during authorized penetration testing.
+description: "Inject NoSQL operators ($ne, $gt, $regex, $where) into MongoDB, CouchDB, and other NoSQL queries to bypass authentication, extract data, and achieve code execution. Use when the application passes user input to NoSQL query operators or JavaScript evaluation contexts."
 keywords:
   - nosql injection
   - mongodb injection

--- a/skills/web/oauth-attacks/SKILL.md
+++ b/skills/web/oauth-attacks/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: oauth-attacks
-description: >
-  Exploit OAuth 2.0 and OpenID Connect vulnerabilities during authorized
-  penetration testing.
+description: "Exploit OAuth 2.0 and OpenID Connect flaws including redirect URI manipulation, authorization code theft, token leakage via referer, scope abuse, and CSRF on callback endpoints. Use when the application implements OAuth/OIDC-based authentication or social login."
 keywords:
   - oauth
   - oauth attack

--- a/skills/web/password-reset-poisoning/SKILL.md
+++ b/skills/web/password-reset-poisoning/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: password-reset-poisoning
-description: >
-  Exploit password reset vulnerabilities during authorized penetration
-  testing.
+description: "Poison password reset links via Host header injection, manipulate reset tokens through predictable generation or reuse, and bypass account recovery flows. Use when the application has a password reset or account recovery feature."
 keywords:
   - password reset poisoning
   - password reset bypass

--- a/skills/web/php-code-injection/SKILL.md
+++ b/skills/web/php-code-injection/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: php-code-injection
-description: >
-  Exploit PHP code evaluation injection via eval(), assert(), preg_replace /e,
-  create_function(), call_user_func(), usort() callbacks, and runtime function
-  creation (runkit, uopz). Distinct from OS command injection (shell operators)
-  and SSTI (template engines) — this targets direct PHP code evaluation of user
-  input.
+description: "Exploit PHP code evaluation injection via eval(), assert(), preg_replace /e, create_function(), and callback functions to execute arbitrary PHP code. Use when user input reaches PHP code evaluation functions rather than shell commands or template engines."
 keywords:
   - php eval injection
   - eval() exploit

--- a/skills/web/python-code-injection/SKILL.md
+++ b/skills/web/python-code-injection/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: python-code-injection
-description: >
-  Exploit Python eval(), exec(), and compile() injection in web applications.
-  Distinct from OS command injection (shell operators) and SSTI (template
-  engines) — this targets direct Python code evaluation of user input.
+description: "Exploit Python eval(), exec(), and compile() injection to execute arbitrary Python code, escape sandboxes, and import dangerous modules. Use when user input reaches Python code evaluation functions rather than shell commands or template engines."
 keywords:
   - python eval injection
   - eval() exploit

--- a/skills/web/race-condition/SKILL.md
+++ b/skills/web/race-condition/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: race-condition
-description: >
-  Exploit race conditions and TOCTOU vulnerabilities in web applications
-  during authorized penetration testing.
+description: "Exploit race conditions via single-packet attacks, HTTP/2 concurrent requests, and Turbo Intruder to trigger TOCTOU flaws like limit overruns, double-spends, and coupon reuse. Use when the application has time-sensitive operations such as balance checks, vote limits, or resource allocation."
 keywords:
   - race condition
   - TOCTOU

--- a/skills/web/request-smuggling/SKILL.md
+++ b/skills/web/request-smuggling/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: request-smuggling
-description: >
-  Guide HTTP request smuggling exploitation during authorized penetration
-  testing.
+description: "Exploit HTTP request smuggling via CL.TE, TE.CL, and H2 desync techniques to bypass security controls, poison caches, and hijack other users' requests. Use when the target sits behind a reverse proxy or load balancer with potential front-end/back-end parsing differences."
 keywords:
   - request smuggling
   - HTTP desync

--- a/skills/web/smb-share-webshell/SKILL.md
+++ b/skills/web/smb-share-webshell/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: smb-share-webshell
-description: >
-  Deploy webshells to IIS, Apache, or Tomcat web roots via SMB share write
-  access. Use when a domain user has write access to a file share that maps
-  to a web server's document root — write a webshell via smbclient/net use,
-  then trigger it via HTTP for RCE. Covers PHP, ASPX, and JSP webshells,
-  .NET impersonation for same-host lateral movement, and internal site
-  discovery.
+description: "Deploy webshells to IIS, Apache, or Tomcat web roots via SMB share write access, then trigger them via HTTP for RCE. Use when a domain user has write access to a file share that maps to a web server's document root."
 keywords:
   - smb webshell
   - smb share write

--- a/skills/web/sql-injection-blind/SKILL.md
+++ b/skills/web/sql-injection-blind/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: sql-injection-blind
-description: >
-  Guide blind SQL injection exploitation (boolean-based, time-based, and
-  out-of-band) during authorized penetration testing.
+description: "Extract database contents through boolean-based, time-based (SLEEP, WAITFOR DELAY, pg_sleep), and out-of-band blind SQL injection when query output is not directly visible. Use when SQL injection is confirmed but the application does not display query results or error messages."
 keywords:
   - blind SQLi
   - boolean-based

--- a/skills/web/sql-injection-error/SKILL.md
+++ b/skills/web/sql-injection-error/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: sql-injection-error
-description: >
-  Guide error-based SQL injection exploitation during authorized penetration
-  testing.
+description: "Extract database contents via error-based SQL injection using EXTRACTVALUE, UPDATEXML, CONVERT/CAST type coercion, and database-specific error functions. Use when the application displays verbose SQL error messages containing query output."
 keywords:
   - error-based SQLi
   - EXTRACTVALUE

--- a/skills/web/sql-injection-stacked/SKILL.md
+++ b/skills/web/sql-injection-stacked/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: sql-injection-stacked
-description: >
-  Guide stacked query SQL injection and second-order injection exploitation
-  during authorized penetration testing.
+description: "Execute stacked SQL queries to run multiple statements (xp_cmdshell, COPY TO PROGRAM, write webshells) and exploit second-order injection where stored payloads trigger in later queries. Use when the injection point supports multi-statement execution or when payloads are stored and executed in a different context."
 keywords:
   - stacked queries
   - multi-statement injection

--- a/skills/web/sql-injection-union/SKILL.md
+++ b/skills/web/sql-injection-union/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: sql-injection-union
-description: >
-  Guide UNION-based SQL injection exploitation during authorized penetration
-  testing.
+description: "Extract database contents via UNION SELECT injection by determining column count, identifying displayed columns, and exfiltrating data from other tables. Use when SQL injection is confirmed and query output is directly visible in the HTTP response."
 keywords:
   - UNION SELECT
   - union injection

--- a/skills/web/ssrf/SKILL.md
+++ b/skills/web/ssrf/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: ssrf
-description: >
-  Guide server-side request forgery (SSRF) exploitation during authorized
-  penetration testing.
+description: "Exploit server-side request forgery to access cloud metadata endpoints (169.254.169.254/IMDS), scan internal networks, read local files via file:// and gopher:// protocols, and pivot through backend services. Use when user input controls a URL or hostname that the server fetches."
 keywords:
   - SSRF
   - server-side request forgery

--- a/skills/web/ssti-freemarker/SKILL.md
+++ b/skills/web/ssti-freemarker/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: ssti-freemarker
-description: >
-  Guide Freemarker/Java server-side template injection exploitation during
-  authorized penetration testing.
+description: "Exploit Java template injection in FreeMarker, Velocity, Thymeleaf, Pebble, and Spring Expression Language (SpEL) to achieve remote code execution via class instantiation and runtime exec. Use when user input is rendered by a Java-based template engine and expression evaluation is confirmed."
 keywords:
   - Freemarker SSTI
   - Java template injection

--- a/skills/web/ssti-jinja2/SKILL.md
+++ b/skills/web/ssti-jinja2/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: ssti-jinja2
-description: >
-  Guide Jinja2/Python server-side template injection exploitation during
-  authorized penetration testing.
+description: "Exploit Python template injection in Jinja2, Mako, Tornado, and Django templates to achieve RCE via MRO traversal, sandbox escapes, and __import__ chains. Use when user input is rendered by a Python-based template engine and expression evaluation is confirmed (e.g. {{7*7}} returns 49)."
 keywords:
   - Jinja2 SSTI
   - Flask SSTI

--- a/skills/web/ssti-twig/SKILL.md
+++ b/skills/web/ssti-twig/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: ssti-twig
-description: >
-  Guide Twig/PHP server-side template injection exploitation during authorized
-  penetration testing.
+description: "Exploit PHP template injection in Twig, Smarty, Blade, and Latte templates to achieve RCE via filter chains, sandbox escapes, and PHP function calls. Use when user input is rendered by a PHP-based template engine and expression evaluation is confirmed."
 keywords:
   - Twig SSTI
   - PHP template injection

--- a/skills/web/tomcat-manager-deploy/SKILL.md
+++ b/skills/web/tomcat-manager-deploy/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: tomcat-manager-deploy
-description: >
-  Deploy WAR files via Apache Tomcat Manager for remote code execution.
-  Use when Tomcat Manager is accessible with valid credentials (manager-script
-  or manager-gui role). Covers WAR generation, deployment via text API and HTML
-  interface, reverse shell delivery, and cleanup. Common initial access vector
-  after credential discovery via LFI, default creds, or config file exposure.
+description: "Deploy malicious WAR files via Apache Tomcat Manager text API and HTML interface for remote code execution and reverse shell delivery. Use when Tomcat Manager is accessible with valid credentials (manager-script or manager-gui role)."
 keywords:
   - tomcat manager
   - WAR deploy

--- a/skills/web/web-discovery/SKILL.md
+++ b/skills/web/web-discovery/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: web-discovery
-description: >
-  Discover web application injection points and route to the correct
-  exploitation skill during authorized penetration testing.
+description: "Enumerate web application attack surface through content discovery, parameter fuzzing, technology fingerprinting, and injection point identification across endpoints. Use when beginning web application testing to map parameters, hidden paths, and potential vulnerabilities before selecting exploitation skills."
 keywords:
   - find vulns
   - fuzz the target

--- a/skills/web/xss-dom/SKILL.md
+++ b/skills/web/xss-dom/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: xss-dom
-description: >
-  Guide DOM-based XSS exploitation during authorized penetration testing.
+description: "Exploit DOM-based XSS by identifying JavaScript sources (location.hash, postMessage, document.referrer) that flow into dangerous sinks (innerHTML, eval, document.write) without sanitization. Use when user-controlled input is processed client-side by JavaScript DOM manipulation."
 keywords:
   - DOM XSS
   - DOM-based XSS

--- a/skills/web/xss-reflected/SKILL.md
+++ b/skills/web/xss-reflected/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: xss-reflected
-description: >
-  Guide reflected XSS exploitation during authorized penetration testing.
+description: "Inject JavaScript payloads into server responses via reflected parameters, bypassing WAF filters, CSP policies, and HTML encoding to achieve session hijacking or credential theft. Use when user input is echoed in the HTTP response without proper output encoding."
 keywords:
   - reflected XSS
   - XSS filter bypass

--- a/skills/web/xss-stored/SKILL.md
+++ b/skills/web/xss-stored/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: xss-stored
-description: >
-  Guide stored (persistent) and blind XSS exploitation during authorized
-  penetration testing.
+description: "Inject persistent JavaScript payloads into stored content (comments, profiles, user-generated content) and deploy blind XSS callbacks via XSS Hunter to capture admin sessions. Use when the application stores and renders user-supplied HTML or JavaScript in pages viewed by other users."
 keywords:
   - stored XSS
   - persistent XSS

--- a/skills/web/xxe/SKILL.md
+++ b/skills/web/xxe/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: xxe
-description: >
-  Guide XML External Entity (XXE) injection exploitation during authorized
-  penetration testing.
+description: "Inject XML external entities to read server files, perform SSRF, and exfiltrate data via out-of-band (OOB) and error-based XXE techniques using DTD declarations. Use when the application parses user-supplied XML input or accepts XML content types."
 keywords:
   - XXE
   - XML injection


### PR DESCRIPTION
Hey 👋 @TheTechromancer

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="1290" alt="image" src="https://github.com/user-attachments/assets/37cdf172-fe98-4a3e-aa06-0a03808f27b8" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| command-injection | 57% | 96% | +39% |
| lfi | 55% | 96% | +41% |
| nosql-injection | 57% | 96% | +39% |
| ssrf | 57% | 96% | +39% |
| xss-reflected | 57% | 96% | +39% |
| xxe | 63% | 96% | +33% |
| 2fa-bypass | 50% | 89% | +39% |
| jwt-attacks | 50% | 89% | +39% |
| ldap-injection | 50% | 89% | +39% |
| oauth-attacks | 50% | 89% | +39% |
| password-reset-poisoning | 50% | 89% | +39% |
| xss-stored | 50% | 89% | +39% |
| sql-injection-union | 63% | 96% | +33% |
| sql-injection-error | 66% | 96% | +30% |
| pivoting-tunneling | 55% | 89% | +34% |
| smb-exploitation | 56% | 89% | +33% |
| container-escapes | 66% | 89% | +23% |
| ad-discovery | 55% | 89% | +34% |
| windows-discovery | 55% | 89% | +34% |
| windows-token-impersonation | 55% | 89% | +34% |
| linux-discovery | 59% | 89% | +30% |
| linux-kernel-exploits | 59% | 89% | +30% |
| windows-uac-bypass | 59% | 89% | +30% |
| windows-service-dll-abuse | 52% | 83% | +31% |
| windows-credential-harvesting | 64% | 89% | +25% |
| kerberos-delegation | 71% | 96% | +25% |
| adcs-access-and-relay | 64% | 89% | +25% |
| browser-exploitation | 73% | 96% | +23% |
| file-upload-bypass | 59% | 89% | +30% |
| race-condition | 59% | 89% | +30% |
| request-smuggling | 59% | 89% | +30% |
| ssti-jinja2 | 59% | 89% | +30% |
| ssti-twig | 59% | 89% | +30% |
| deserialization-php | 63% | 90% | +27% |
| sql-injection-stacked | 63% | 89% | +26% |
| cors-misconfiguration | 55% | 81% | +26% |
| web-discovery | 55% | 81% | +26% |
| csrf | 55% | 89% | +34% |
| ssti-freemarker | 55% | 83% | +28% |
| xss-dom | 50% | 81% | +31% |
| deserialization-dotnet | 59% | 83% | +24% |
| idor | 59% | 81% | +22% |
| deserialization-java | 66% | 89% | +23% |
| sql-injection-blind | 68% | 89% | +21% |
| adcs-persistence | 73% | 89% | +16% |
| adcs-template-abuse | 73% | 89% | +16% |
| linux-cron-service-abuse | 73% | 89% | +16% |
| linux-sudo-suid-capabilities | 73% | 89% | +16% |
| php-code-injection | 80% | 96% | +16% |
| kerberos-ticket-forging | 88% | 96% | +8% |
| retrospective | 73% | 81% | +8% |
| network-recon | 73% | 81% | +8% |
| linux-file-path-abuse | 81% | 89% | +8% |
| python-code-injection | 80% | 89% | +9% |
| acl-abuse | 80% | 89% | +9% |
| auth-coercion-relay | 80% | 89% | +9% |
| credential-dumping | 80% | 89% | +9% |
| kerberos-roasting | 80% | 89% | +9% |
| password-spraying | 80% | 89% | +9% |
| windows-kernel-exploits | 80% | 89% | +9% |

**Average: 66% → 89% (+23%)**

<details>
<summary>What changed</summary>

All 77 skills received frontmatter description improvements:

- **Converted description format** from YAML block scalar (`>`) to quoted strings — standard format that avoids parsing edge cases
- **Added specific concrete actions** to each description — replaced vague "Guide X exploitation" with technique-specific verbs (e.g. "Exploit unquoted service paths, writable binaries, weak DACLs, and DLL search-order hijacking")
- **Added "Use when..." clauses** — explicit trigger guidance for skill selection (e.g. "Use when user-controlled input reaches OS shell commands via system(), exec(), or popen()")
- **Preserved all body content** — no methodology, payload, or workflow changes; only frontmatter descriptions were modified
- **Preserved all other frontmatter** — name, keywords, tools, opsec fields untouched
- **Respected token budget** — descriptions kept to 2-3 sentences per writing-skills.md guidelines; no body expansion

Changes follow the skill conventions in `docs/writing-skills.md`: descriptions focus on technique scope and when to use it, without trigger phrases, negative conditions, or OPSEC details (those stay in keywords/opsec fields).

</details>

<details>
<summary>🤖 Tessl Skill Review GitHub Action — automated feedback on future SKILL.md PRs</summary>

This PR also adds `.github/workflows/skill-review.yml` — a lightweight GitHub Action that automatically reviews skill changes on future PRs:

- **What runs:** On PRs that change `**/SKILL.md`, the workflow runs [`tesslio/skill-review`](https://github.com/tesslio/skill-review) and posts **one** PR comment with Tessl scores and feedback (updated on new pushes).
- **Zero extra accounts:** Contributors do **not** need a Tessl login — only the default **`GITHUB_TOKEN`** is used to post the comment.
- **Non-blocking by default:** The check is **feedback-only** — no surprise red CI. It won't fail your build.
- **Not a build replacement:** This is review automation for skill markdown quality — it doesn't replace your shellcheck, ruff, or lint CI pipeline.
- **Optional gate:** If you want PRs to fail on low scores later, add `with: fail-threshold: 70` to the action step.

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏