### PR TITLE
Rename exercised→actioned, improve config.sh Sliver setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,7 @@
       "mcp__state__*",
       "mcp__skill-router__*",
       "mcp__shell-server__*",
+      "mcp__sliver-server__*",
       "mcp__nmap-server__*",
       "mcp__browser-server__*",
       "mcp__rdp-server__*"

--- a/.mcp.json
+++ b/.mcp.json
@@ -56,6 +56,10 @@
         "python",
         "server.py"
       ]
+    },
+    "sliver-server": {
+      "type": "sse",
+      "url": "http://127.0.0.1:8023/sse"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,11 @@ All notable changes to red-run will be documented in this file. Format follows [
 
 - **Lead runs as Sonnet** — `run.sh` launches with `--model sonnet` to reduce
   token cost. Research teammate model is operator's choice (sonnet or opus).
-- **Terminology**: `exploited` → `exercised` across state DB, dashboard,
-  templates, and docs (schema migration v19→v20)
-- **Terminology**: `exploitable` → `actionable`, `exploitation` → `exercise`
+- **Terminology**: `exploited` → `actioned` across state DB, dashboard,
+  templates, and docs (schema migrations v19→v22)
+- **Terminology**: `exploitable` → `actionable`, `exploitation` → `action`
   in teammate templates and docs
-- **state-mgr auto-exercises vulns** on provenance-linked writes and
+- **state-mgr auto-actions vulns** on provenance-linked writes and
   refuses orphaned writes with missing chain links.
 - **Teammates establish shells directly** via shell-server, then hand off to
   shell-mgr (reversed from earlier design where shell-mgr established)
@@ -66,8 +66,8 @@ All notable changes to red-run will be documented in this file. Format follows [
 - Sonnet 1M override removed (rate limits), teammates spawn as Sonnet 200k
 - Listener handoff deadlock eliminated by shell establishment redesign
 - shell-server `send_command` on PowerShell iex shells (PS-native wrapper)
-- Exercised vulns render as blue action nodes (stale `EXPLOITED` label fixed)
-- Exercised vuln routing extended to `via_credential_id` (not just access)
+- Actioned vulns render as blue action nodes (stale `EXPLOITED` label fixed)
+- Actioned vuln routing extended to `via_credential_id` (not just access)
 - sliver-server `execute` args splitting and `generate_implant` reliability
 - `sliver console --rc` hang on exit
 - Config wizard re-asking scan type and proxy when config.yaml has values
@@ -138,9 +138,9 @@ sanitization pass to reduce AUP filter sensitivity.
   custom tooling, update accordingly.
 - **Terminology sanitized across all templates and orchestrator.** Offensive
   terms replaced with neutral equivalents to reduce AUP filter sensitivity:
-  attack → operations, exploit (verb) → exercise, payload → artifact,
+  attack → operations, exploit (verb) → action, payload → artifact,
   cracking → recovery, kill chain → access chain, evasion → bypass,
-  post-exploitation → post-access. State DB values (`exploited`, `blocked`,
+  post-exploitation → post-access. State DB values (`actioned`, `blocked`,
   `cracked`) and technique taxonomy (Kerberoasting, SQL injection, etc.)
   are unchanged.
 - **State schema `host` column renamed to `ip`**, `hostname` column added.
@@ -228,7 +228,7 @@ sanitization pass to reduce AUP filter sensitivity.
 - **Shell-server HTTP endpoints** — `GET /status` and `POST /clear` for
   session management outside MCP protocol.
 - **HARD STOP — VULN CONFIRMED** on all 5 enum templates — stops, writes to
-  state, messages lead, does not exercise.
+  state, messages lead, does not action.
 - **HARD STOP — SHELL** on web-enum — scope enforcement for accidental shell
   access.
 - **Execution Achieved hard stop** — highest priority, triggers immediate host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to red-run will be documented in this file. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## 2026-04-01
+
+### Changed
+
+- **config.sh sliver setup** — removed daemon lifecycle management (unpack,
+  start, restart, operator config generation). config.sh now checks for an
+  existing operator config and offers interactive options: generate from local
+  daemon, provide path to existing config (local or remote C2), or skip.
+- **config.sh sliver detection** — detects running daemon or existing config
+  instead of checking for client/server binaries on PATH
+
+### Fixed
+
+- **config.sh silent exit** — `sliver-server unpack --force` returning non-zero
+  killed the script silently due to `set -e` with stderr suppressed
+
+### Added
+
+- **Sliver remote C2 support** — config.sh and installation docs now cover
+  running sliver-server on a separate host with only the client on the red-run
+  box
+- **sliver-server MCP pre-registered** — `.mcp.json` and `.claude/settings.json`
+  include sliver-server entries by default
+- **Installation docs** — step-by-step Sliver setup for both local and remote
+  deployment models
+
 ## 2026-03-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ See each server's `README.md` for tool details.
 - **Recon** (`skills/network/network-recon/`): Host discovery, port scanning, OS fingerprinting — produces a port/service map
 - **Enumeration** (`skills/network/*-enumeration/`): Per-service deep enumeration (SMB, databases, remote access, infrastructure)
 - **Discovery** (`skills/<category>/*-discovery/`): Identifies vulnerabilities, reports findings generically (orchestrator routes to technique skills via `search_skills()`)
-- **Technique** (`skills/<category>/<technique>/`): Exercises a specific vulnerability class
+- **Technique** (`skills/<category>/<technique>/`): Actions a specific vulnerability class
 
 ### Inter-Skill Routing
 

--- a/config.sh
+++ b/config.sh
@@ -103,7 +103,9 @@ case "${q5:-1}" in
             # Unpack Sliver assets (Go toolchain, implant templates) on first run
             if [[ ! -d "${HOME}/.sliver" ]] || [[ ! -d "${HOME}/.sliver/go" ]]; then
                 echo "  Unpacking Sliver assets (first run, may take a moment)..."
-                sliver-server unpack --force 2>/dev/null
+                if ! sliver-server unpack --force 2>/dev/null; then
+                    echo "  Warning: sliver-server unpack failed (may already be unpacked)."
+                fi
             fi
             echo "  Sliver operator config setup:"
             if [[ -f "$default_cfg" ]]; then

--- a/config.sh
+++ b/config.sh
@@ -76,11 +76,14 @@ esac
 echo ""
 echo "Q5 — Shell backend"
 echo "  1) shell-server  (raw TCP/PTY, always available)"
-if command -v sliver-server &>/dev/null || command -v sliver &>/dev/null; then
-    echo "  2) sliver        (Sliver C2 — detected)"
+if pgrep -f "sliver-server daemon" &>/dev/null; then
+    echo "  2) sliver        (Sliver C2 — daemon running)"
+    has_sliver=1
+elif [[ -f "engagement/sliver.cfg" ]]; then
+    echo "  2) sliver        (Sliver C2 — config found, daemon not running)"
     has_sliver=1
 else
-    echo "  2) sliver        (not installed)"
+    echo "  2) sliver        (not configured)"
     has_sliver=0
 fi
 echo "  3) custom        (your own C2 + MCP server)"
@@ -93,52 +96,59 @@ custom_ref=""
 
 case "${q5:-1}" in
     2)
-        if [[ "$has_sliver" -eq 0 ]]; then
-            echo "  Sliver not detected. Install sliver-server first."
-            echo "  Falling back to shell-server."
-        else
+        default_cfg="engagement/sliver.cfg"
+        if [[ -f "$default_cfg" ]]; then
+            echo "  Found operator config: $default_cfg"
             shell_backend="sliver"
-            default_cfg="engagement/sliver.cfg"
+            sliver_config="$default_cfg"
+        else
             echo ""
-            # Unpack Sliver assets (Go toolchain, implant templates) on first run
-            if [[ ! -d "${HOME}/.sliver" ]] || [[ ! -d "${HOME}/.sliver/go" ]]; then
-                echo "  Unpacking Sliver assets (first run, may take a moment)..."
-                if ! sliver-server unpack --force 2>/dev/null; then
-                    echo "  Warning: sliver-server unpack failed (may already be unpacked)."
-                fi
-            fi
-            echo "  Sliver operator config setup:"
-            if [[ -f "$default_cfg" ]]; then
-                echo "  Found existing config: $default_cfg"
-                read -rp "  Use this config? [Y/n] " use_existing
-                if [[ "${use_existing,,}" != "n" ]]; then
-                    sliver_config="$default_cfg"
-                fi
-            fi
-            if [[ -z "$sliver_config" ]]; then
-                echo "  Generating operator config..."
-                rm -f "$default_cfg"
-                if sliver-server operator --name red-run --lhost 127.0.0.1 --permissions all --save "$default_cfg" 2>/dev/null; then
-                    sliver_config="$default_cfg"
-                    echo "  Config saved to $default_cfg"
-                    # Restart daemon so new mTLS certs take effect
-                    echo "  Restarting Sliver daemon for new config..."
-                    pkill -f "sliver-server daemon" 2>/dev/null
-                    sleep 2
-                    sliver-server daemon &>/dev/null &
-                    sleep 2
-                    # Import config into sliver client
-                    if command -v sliver &>/dev/null; then
-                        sliver import "$default_cfg" 2>/dev/null
+            echo "  No operator config found at $default_cfg."
+            echo ""
+            echo "  1) Generate now (local daemon — sliver-server must be running)"
+            echo "  2) Provide path to existing config (local or from remote C2)"
+            echo "  3) Cancel — fall back to shell-server"
+            read -rp "  Choice [3]: " sliver_setup
+            case "${sliver_setup:-3}" in
+                1)
+                    if ! pgrep -f "sliver-server daemon" &>/dev/null; then
+                        echo "  Sliver daemon not running."
+                        echo "  Start it first:  sliver-server daemon &"
+                        echo "  Then re-run ./config.sh."
+                        echo "  Falling back to shell-server."
+                    elif ! command -v sliver-server &>/dev/null; then
+                        echo "  sliver-server not found on PATH."
+                        echo "  See docs/installation.md for install steps."
+                        echo "  Falling back to shell-server."
+                    else
+                        echo "  Generating operator config..."
+                        if sliver-server operator --name red-run --lhost 127.0.0.1 \
+                            --permissions all --save "$default_cfg" 2>&1; then
+                            echo "  Config saved to $default_cfg"
+                            shell_backend="sliver"
+                            sliver_config="$default_cfg"
+                        else
+                            echo "  Failed to generate config."
+                            echo "  Falling back to shell-server."
+                        fi
                     fi
-                else
-                    echo "  Failed to generate config. Is sliver-server running?"
-                    echo "  Start it with: sliver-server daemon &"
-                    echo "  Then re-run this setup."
+                    ;;
+                2)
+                    read -rp "  Path to operator config: " cfg_path
+                    if [[ -f "$cfg_path" ]]; then
+                        cp "$cfg_path" "$default_cfg"
+                        echo "  Copied to $default_cfg"
+                        shell_backend="sliver"
+                        sliver_config="$default_cfg"
+                    else
+                        echo "  File not found: $cfg_path"
+                        echo "  Falling back to shell-server."
+                    fi
+                    ;;
+                *)
                     echo "  Falling back to shell-server."
-                    shell_backend="shell-server"
-                fi
-            fi
+                    ;;
+            esac
         fi
         ;;
     3)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -66,7 +66,7 @@ Enumeration teammates **discover attack surface** and identify vulnerabilities. 
 
 ### Operations teammates
 
-Operations teammates **exercise specific vulnerabilities**. They load technique skills, execute the methodology, and report results. All findings are messaged to state-mgr for state persistence and to the lead for routing decisions.
+Operations teammates **action specific vulnerabilities**. They load technique skills, execute the methodology, and report results. All findings are messaged to state-mgr for state persistence and to the lead for routing decisions.
 
 ## State Access Pattern
 

--- a/docs/engagement-state.md
+++ b/docs/engagement-state.md
@@ -53,8 +53,8 @@ The `secret_type` field in `credentials` supports: `password`, `ntlm_hash`, `net
 
 Vulns have three statuses:
 
-- **found** — Identified but not yet exercised
-- **exploited** — Successfully exercised, access obtained
+- **found** — Identified but not yet actioned
+- **exploited** — Successfully actioned, access obtained
 - **blocked** — Exploitation attempted but failed or not possible
 
 ### Pivot map
@@ -66,7 +66,7 @@ SQLi on 10.10.10.5:/search  →  DB creds for 10.10.10.1:mssql
 ADCS ESC1 on DC01            →  Domain Admin TGT
 ```
 
-The orchestrator reads the pivot map to identify unexercised chains and decide which skill to invoke next.
+The orchestrator reads the pivot map to identify un-actioned chains and decide which skill to invoke next.
 
 ## State server architecture
 
@@ -91,7 +91,7 @@ The orchestrator uses state queries to make routing decisions:
 ```
 get_state_summary()           → Full engagement snapshot (~200 lines)
 get_credentials(untested_only=True) → Creds not yet tested everywhere
-get_vulns(status="found")     → Vulns not yet exercised
+get_vulns(status="found")     → Vulns not yet actioned
 get_pivot_map()               → Chains to follow
 get_blocked()                 → Dead ends to avoid
 get_access(active_only=True)  → Current footholds

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,17 +18,66 @@ red-run works out of the box with shell-server (raw TCP reverse shells + interac
 
 | C2 | Components | Install |
 |----|-----------|---------|
-| [Sliver](https://github.com/BishopFox/sliver) | Server + Client (both required) | See below |
+| [Sliver](https://github.com/BishopFox/sliver) | Server + Client | See below |
 
-**Sliver install** (both binaries needed — server for the daemon, client for implant generation):
+**Sliver install** — two deployment models depending on whether the Sliver
+server runs on the same box as red-run or on a dedicated C2 host.
+
+#### Local (server + client on the same box)
+
+**Step 1 — Download binaries:**
 ```bash
-# Server (~260MB)
+# Server (~260MB) — runs the daemon, generates operator configs
 curl -L https://github.com/BishopFox/sliver/releases/latest/download/sliver-server_linux-amd64 \
   -o ~/.local/bin/sliver-server && chmod +x ~/.local/bin/sliver-server
-# Client (~38MB)
+
+# Client (~38MB) — implant generation, interactive console
 curl -L https://github.com/BishopFox/sliver/releases/latest/download/sliver-client_linux-amd64 \
   -o ~/.local/bin/sliver && chmod +x ~/.local/bin/sliver
 ```
+
+**Step 2 — Unpack assets** (downloads Go toolchain + implant templates, ~1–2 min on first run):
+```bash
+sliver-server unpack --force
+```
+
+**Step 3 — Start the daemon:**
+```bash
+sliver-server daemon &
+```
+Wait a few seconds for it to initialize. Verify with `pgrep -f "sliver-server daemon"`.
+
+**Step 4 — Run config.sh** and select sliver as the shell backend:
+```bash
+cd /path/to/red-run
+./config.sh
+```
+It will prompt you to generate an operator config (how the red-run MCP server
+authenticates to the daemon). If the daemon is running, it handles everything.
+
+#### Remote (server on a dedicated C2 host)
+
+Only the sliver client is needed on the red-run box. The server runs elsewhere.
+
+**On the red-run box** — install the client:
+```bash
+curl -L https://github.com/BishopFox/sliver/releases/latest/download/sliver-client_linux-amd64 \
+  -o ~/.local/bin/sliver && chmod +x ~/.local/bin/sliver
+```
+
+**On the C2 host** — generate an operator config for red-run:
+```bash
+sliver-server operator --name red-run --lhost <C2_IP> \
+  --permissions all --save red-run.cfg
+```
+
+**Copy** `red-run.cfg` to the red-run box as `engagement/sliver.cfg`, then run `./config.sh`.
+
+#### Notes
+
+Both setups need the sliver client on the red-run box for implant generation.
+The `sliver-server` binary is only needed where the daemon runs.
+`config.sh` detects `engagement/sliver.cfg` automatically — no manual config edits needed.
 
 More C2 frameworks (Mythic, Havoc) planned. Custom C2 integration is supported via operator-provided MCP servers and reference docs.
 

--- a/docs/running-an-engagement.md
+++ b/docs/running-an-engagement.md
@@ -125,7 +125,7 @@ Here's how it works under the hood:
 
 3. **Loading** — The orchestrator reviews the search results (each includes the skill's description and OPSEC rating), picks the best match, and tells the teammate to load it via `get_skill("ajp-ghostcat")`. The teammate gets the full `SKILL.md` content — methodology, payloads, troubleshooting — injected into its context.
 
-The "augmented generation" part is that Claude doesn't rely on its training data to know how to exercise AJP Ghostcat. Instead, the skill's methodology is retrieved from the local library and injected into the prompt, giving the teammate precise, tested instructions rather than general knowledge.
+The "augmented generation" part is that Claude doesn't rely on its training data to know how to action AJP Ghostcat. Instead, the skill's methodology is retrieved from the local library and injected into the prompt, giving the teammate precise, tested instructions rather than general knowledge.
 
 ### Routing
 
@@ -170,7 +170,7 @@ Hard stops prevent the orchestrator from making high-impact decisions autonomous
 
 After each task completes, the lead runs a **post-task checkpoint** and decision logic using `get_state_summary()`:
 
-1. **Unexercised vulns?** → Route technique skill to ops teammate
+1. **Un-actioned vulns?** → Route technique skill to ops teammate
 2. **New access (shell/login)?** → **Execution Achieved** hard stop (see below)
 3. **Untested credentials?** → Spawn per-user credential context enum teammate + password reuse spray
 4. **Unrecovered hashes?** → Hashes Found hard stop
@@ -185,7 +185,7 @@ The orchestrator has mandatory pause points. Every task assignment requires oper
 | Hard Stop | Trigger | Action |
 |-----------|---------|--------|
 | **Execution Achieved** | New shell or login gained | Immediate: shell upgrade → spawn host enum teammate → AD enum if domain user. Highest priority — don't wait for other tasks. |
-| **Vuln Confirmed** | Enum teammate confirms a vuln | Enum teammate stops, writes to state-mgr, messages lead. Does NOT exercise. Lead routes to ops teammate. |
+| **Vuln Confirmed** | Enum teammate confirms a vuln | Enum teammate stops, writes to state-mgr, messages lead. Does NOT action. Lead routes to ops teammate. |
 | **Credential Context Enum** | New credential captured | Spawn dedicated `net-enum-<username>` to enumerate what that identity can access: shares, services, web roles, AD context. One teammate per user. |
 | **Technique-Vuln Linkage** | Credential from active technique | Teammate must create a vuln record for the technique before the credential. State-mgr rejects credentials without `via_vuln_id` when the source implies a technique. |
 | **Hostname Resolution** | Unresolvable hostname | Operator runs hosts-update script |

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -21,7 +21,7 @@ Discovery skills run in agents with **state** access, allowing them to write fin
 
 ### Technique Skills
 
-**Technique skills** exercise specific vulnerability classes. Each covers one technique thoroughly — assessment, confirmation, exploitation, and escalation/pivot routing. There are 62 technique skills across all categories.
+**Technique skills** action specific vulnerability classes. Each covers one technique thoroughly — assessment, confirmation, exploitation, and escalation/pivot routing. There are 62 technique skills across all categories.
 
 Technique skills run in agents with **state** access. They write critical discoveries (captured hashes, credentials, confirmed vulns) mid-run and report all findings in their return summary.
 

--- a/operator/state-viewer/server.py
+++ b/operator/state-viewer/server.py
@@ -304,7 +304,7 @@ tr:hover td { background: var(--bg2); }
 .sev-info { background: var(--gray); color: #000; }
 .status-active { color: var(--green); }
 .status-revoked, .status-down, .status-closed { color: var(--dim); text-decoration: line-through; }
-.status-exercised { color: var(--green); }
+.status-actioned { color: var(--green); }
 .status-identified { color: var(--yellow); }
 .status-blocked { color: var(--red); }
 .filter-bar { margin: 12px 0; }
@@ -435,7 +435,7 @@ function renderLight() {
 function renderCards() {
   const c = document.getElementById('summary-cards');
   const actionableVulns = state.vulns.filter(v => v.status === 'found');
-  const exercisedVulns = state.vulns.filter(v => v.status === 'exercised');
+  const actionedVulns = state.vulns.filter(v => v.status === 'actioned');
   const sevCounts = {};
   actionableVulns.forEach(v => { sevCounts[v.severity] = (sevCounts[v.severity]||0) + 1; });
   const sevStr = ['critical','high','medium','low','info']
@@ -445,7 +445,7 @@ function renderCards() {
     card(state.credentials.length, 'Credentials'),
     card(state.access.filter(a=>a.active).length, 'Active Access'),
     card(actionableVulns.length, 'Actionable', sevStr),
-    card(exercisedVulns.length, 'Exercised'),
+    card(actionedVulns.length, 'Actioned'),
     card(state.pivot_map.length, 'Pivots'),
     card(state.tunnels.filter(t=>t.status==='active').length, 'Tunnels'),
     card(state.blocked.length, 'Blocked'),
@@ -502,7 +502,7 @@ function renderTables() {
     if (ss) {
       const col = ss.col;
       const orderedCols = { severity: {critical:0,high:1,medium:2,low:3,info:4},
-        status: {exercised:0,found:1,blocked:2}, retry: {with_context:0,later:1,no:2} };
+        status: {actioned:0,found:1,blocked:2}, retry: {with_context:0,later:1,no:2} };
       rows = [...rows].sort((a,b) => {
         let va = getCellValue(a, col, def), vb = getCellValue(b, col, def);
         const ord = orderedCols[col];
@@ -697,17 +697,17 @@ function renderFlowGraph() {
     }
     const techniqueLabel = v.technique_id ? `[${v.technique_id}] ` : '';
     let vulnNode;
-    if (v.status === 'exercised') {
-      // Exercised vuln becomes an ACTION node — the vuln is the technique
+    if (v.status === 'actioned') {
+      // Actioned vuln becomes an ACTION node — the vuln is the technique
       vulnNode = {
         id: `vuln:${v.id}`, type: 'action',
         label: `${techniqueLabel}${trunc(v.title, 35)}`,
         sublabel: v.vuln_type || '',
         hostLabel: v.ip || '',
-        detail: `Exercised: ${v.title}\n${v.severity}${v.vuln_type ? '\ntype: ' + v.vuln_type : ''}${v.details ? '\n' + v.details : ''}`,
+        detail: `Actioned: ${v.title}\n${v.severity}${v.vuln_type ? '\ntype: ' + v.vuln_type : ''}${v.details ? '\n' + v.details : ''}`,
         borderColor: '#58a6ff',
         headerColor: '#1f6feb',
-        headerText: 'EXERCISED',
+        headerText: 'ACTIONED',
         chain_order: v.chain_order || 0,
       };
     } else {
@@ -753,16 +753,16 @@ function renderFlowGraph() {
   }
 
   // --- Intermediate vuln detection ---
-  // When an exercised vuln shares via_access_id or via_credential_id with a
-  // downstream node, the exercised vuln (now an action node) is the technique
+  // When an actioned vuln shares via_access_id or via_credential_id with a
+  // downstream node, the actioned vuln (now an action node) is the technique
   // that produced the result. Route through: source → vuln(action) → downstream.
-  const exercisedVulnByAccess = {};  // access_id → vuln node id (action-styled)
-  const exercisedVulnByCred = {};    // credential_id → vuln node id (action-styled)
+  const actionedVulnByAccess = {};  // access_id → vuln node id (action-styled)
+  const actionedVulnByCred = {};    // credential_id → vuln node id (action-styled)
   for (const v of state.vulns) {
     if (v.in_graph === 0 || v.severity === 'info') continue;
-    if (v.status === 'exercised' && nodeById[`vuln:${v.id}`]) {
-      if (v.via_access_id) exercisedVulnByAccess[v.via_access_id] = `vuln:${v.id}`;
-      if (v.via_credential_id) exercisedVulnByCred[v.via_credential_id] = `vuln:${v.id}`;
+    if (v.status === 'actioned' && nodeById[`vuln:${v.id}`]) {
+      if (v.via_access_id) actionedVulnByAccess[v.via_access_id] = `vuln:${v.id}`;
+      if (v.via_credential_id) actionedVulnByCred[v.via_credential_id] = `vuln:${v.id}`;
     }
   }
 
@@ -774,14 +774,14 @@ function renderFlowGraph() {
       edges.push({ from: credNode, to: `access:${a.id}`, color: '#3fb950' });
     }
     // vuln → access: if via_vuln_id is set, that vuln specifically produced this
-    // access. Use it directly — don't rely on the exercisedVulnByAccess heuristic
-    // which breaks when multiple exercised vulns share the same via_access_id.
+    // access. Use it directly — don't rely on the actionedVulnByAccess heuristic
+    // which breaks when multiple actioned vulns share the same via_access_id.
     if (a.via_vuln_id && nodeById[`vuln:${a.via_vuln_id}`]) {
       edges.push({ from: `vuln:${a.via_vuln_id}`, to: `access:${a.id}`, color: '#3fb950' });
     } else if (a.via_access_id && nodeById[`access:${a.via_access_id}`]) {
-      // No explicit via_vuln_id — try the exercisedVulnByAccess heuristic for
+      // No explicit via_vuln_id — try the actionedVulnByAccess heuristic for
       // routing through the intermediate technique, or fall back to direct access→access
-      const ivuln = exercisedVulnByAccess[a.via_access_id];
+      const ivuln = actionedVulnByAccess[a.via_access_id];
       if (ivuln && nodeById[ivuln]) {
         edges.push({ from: ivuln, to: `access:${a.id}`, color: '#3fb950' });
       } else {
@@ -806,14 +806,14 @@ function renderFlowGraph() {
       else if (/runas|config|enum/.test(src)) actionLabel = 'Credential Discovery';
       else if (/dump|extract|secret/.test(src)) actionLabel = 'Credential Extraction';
       else if (/lfi|unc|file/.test(src)) actionLabel = 'File Coercion';
-      // Route through intermediate exercised vuln if one exists on the parent access
-      const ivuln = exercisedVulnByAccess[c.via_access_id];
+      // Route through intermediate actioned vuln if one exists on the parent access
+      const ivuln = actionedVulnByAccess[c.via_access_id];
       const sourceId = (ivuln && nodeById[ivuln]) ? ivuln : `access:${c.via_access_id}`;
       const edgeKey = `${sourceId}->${credDst}`;
       if (credEdgeSeen.has(edgeKey)) continue;
       credEdgeSeen.add(edgeKey);
       if (ivuln && nodeById[ivuln]) {
-        // Exercised vuln is already an action node — direct edge to credential
+        // Actioned vuln is already an action node — direct edge to credential
         edges.push({ from: sourceId, to: credDst, color: '#58a6ff' });
       } else {
         // No intermediate vuln — insert synthetic action between access and credential
@@ -823,15 +823,15 @@ function renderFlowGraph() {
           srcNode.chain_order, dstNode.chain_order);
       }
     }
-    // vuln → credential — exercised vulns are already action-styled, direct edge
+    // vuln → credential — actioned vulns are already action-styled, direct edge
     const vulnSrc = c.via_vuln_id && nodeById[`vuln:${c.via_vuln_id}`] ? `vuln:${c.via_vuln_id}` : null;
     if (vulnSrc) {
       const edgeKey = `${vulnSrc}->${credDst}`;
       if (credEdgeSeen.has(edgeKey)) continue;
       credEdgeSeen.add(edgeKey);
       const srcVuln = state.vulns.find(v => v.id === c.via_vuln_id);
-      if (srcVuln && srcVuln.status === 'exercised') {
-        // Exercised vuln is already an action node — direct edge to credential
+      if (srcVuln && srcVuln.status === 'actioned') {
+        // Actioned vuln is already an action node — direct edge to credential
         edges.push({ from: vulnSrc, to: credDst, color: '#58a6ff' });
       } else {
         // Found vuln (asset) still needs a synthetic action between vuln and credential
@@ -850,7 +850,7 @@ function renderFlowGraph() {
     }
   }
 
-  // access/credential/vuln → vuln (found/exercised vuln) — direct edge (vuln IS the finding)
+  // access/credential/vuln → vuln (found/actioned vuln) — direct edge (vuln IS the finding)
   for (const v of state.vulns) {
     if (v.in_graph === 0) continue;
     if (v.severity === 'info') continue;
@@ -923,7 +923,7 @@ function renderFlowGraph() {
   }
   const colKeys = Object.keys(colMap).map(Number).sort((a, b) => a - b);
 
-  // Sort within each column: exercised vulns first, then actions, then access, then creds
+  // Sort within each column: actioned vulns first, then actions, then access, then creds
   const typeSortOrder = { 'vuln': 0, 'action': 1, 'access': 2, 'asset': 3 };
   function nodeSort(a, b) {
     const aType = a.id.startsWith('vuln:') ? 'vuln' : a.id.startsWith('action:') ? 'action'

--- a/teammates/README.md
+++ b/teammates/README.md
@@ -56,8 +56,8 @@ or agent definitions — they're prompt templates.
 - Model is specified by the orchestrator in the spawn instruction, not in the template
 - Sonnet teammates spawn as Sonnet 200k by default; for 1M context, set
   `ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6[1m]` in `.claude/settings.json` env
-- Enum teammates discover and report — they don't exercise findings
-- Ops teammates exercise assigned vulns — they don't discover new ones
+- Enum teammates discover and report — they don't action findings
+- Ops teammates action assigned vulns — they don't discover new ones
 - On-demand teammates handle one task and get dismissed
 - All state writes go through state-mgr via structured `[action]` messages
 - All shell lifecycle ops go through shell-mgr (listeners, processes, upgrades);

--- a/teammates/ad-enum.md
+++ b/teammates/ad-enum.md
@@ -7,7 +7,7 @@ multiple tasks.
 
 > **HARD STOP — VULN CONFIRMED:** When you confirm an actionable condition
 > (Kerberoastable SPN, delegation abuse path, ACL chain, ADCS misconfiguration,
-> coercion vector) — STOP. Do NOT exercise it.
+> coercion vector) — STOP. Do NOT action it.
 > 1. Message state-mgr: `[add-vuln]` with details
 > 2. Wait for `[vuln-written] id=<N>` confirmation
 > 3. Message lead with the finding + vuln ID
@@ -77,7 +77,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
 [add-pivot] from_ip=<ip> to_subnet=<cidr> pivot_type="<type>"
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -128,7 +128,7 @@ one-shot scripts) — `dangerouslyDisableSandbox: true` for network commands.
 
 ## Scope Boundaries
 
-Discover AD assessment surface — don't exercise. See HARD STOP — VULN CONFIRMED.
+Discover AD assessment surface — don't action. See HARD STOP — VULN CONFIRMED.
 
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.
 - Do NOT perform network scanning, web app testing, or host-level privesc.

--- a/teammates/ad-ops.md
+++ b/teammates/ad-ops.md
@@ -67,7 +67,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_access_id=<M> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
 [add-pivot] from_ip=<ip> to_subnet=<cidr> pivot_type="<type>"
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -145,7 +145,7 @@ one-shot scripts) — `dangerouslyDisableSandbox: true` for network commands.
 
 ## Scope Boundaries
 
-Exercise the assigned AD vulnerability using the loaded technique skill. Don't
+Action the assigned AD vulnerability using the loaded technique skill. Don't
 enumerate the domain — the lead routes technique execution to ad-enum.
 
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.

--- a/teammates/lin-enum.md
+++ b/teammates/lin-enum.md
@@ -7,7 +7,7 @@ tasks.
 
 > **HARD STOP — VULN CONFIRMED:** When you confirm a privesc vector (writable
 > SUID binary, abusable sudo rule, writable cron job, kernel CVE match,
-> container escape path) — STOP. Do NOT exercise it.
+> container escape path) — STOP. Do NOT action it.
 > 1. Message state-mgr: `[add-vuln]` with details
 > 2. Wait for `[vuln-written] id=<N>` confirmation
 > 3. Message lead with the finding + vuln ID
@@ -73,7 +73,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_access_id=<M> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
 [add-pivot] from_ip=<ip> to_subnet=<cidr> pivot_type="<type>"
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -128,8 +128,8 @@ Enumeration commands often run ON the target through a shell, not from the attac
 
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.
 - Do NOT run Windows commands — Linux hosts only. Wrong OS → report, return.
-- Do NOT exercise privesc vectors — see HARD STOP — VULN CONFIRMED above.
-- Do NOT exercise web services, chain SSRF, or use curl to proxy commands
+- Do NOT action privesc vectors — see HARD STOP — VULN CONFIRMED above.
+- Do NOT action web services, chain SSRF, or use curl to proxy commands
   through web apps. One fingerprint curl for `add_pivot()` is fine — anything
   beyond that is web teammate's job. Report the finding and return.
 - Do NOT perform network scanning or AD enumeration.

--- a/teammates/lin-ops.md
+++ b/teammates/lin-ops.md
@@ -5,7 +5,7 @@ engagement. You handle technique execution: sudo/SUID abuse, kernel techniques,
 cron/service abuse, container escapes, file path abuse. You persist
 across multiple tasks.
 
-**Scope:** Exercise the assigned privesc vector using the loaded technique skill.
+**Scope:** Action the assigned privesc vector using the loaded technique skill.
 Don't run full enumeration — the lead routes discovery to lin-enum.
 
 > **HARD STOP — CREDENTIALS:** If you capture credentials (passwords, hashes,
@@ -63,7 +63,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_access_id=<M> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
 [add-pivot] from_ip=<ip> to_subnet=<cidr> pivot_type="<type>"
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -120,8 +120,8 @@ Artifact caught → **stop, don't retry.** Return structured AV-blocked context.
 
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.
 - Do NOT run Windows commands — Linux hosts only. Wrong OS → report, return.
-- Do NOT run full enumeration — exercise the assigned vector only. The lead routes discovery to lin-enum.
-- Do NOT exercise web services, chain SSRF, or use curl to proxy commands
+- Do NOT run full enumeration — action the assigned vector only. The lead routes discovery to lin-enum.
+- Do NOT action web services, chain SSRF, or use curl to proxy commands
   through web apps. Report the finding and return.
 - Do NOT perform network scanning or AD enumeration.
 - Do NOT recover hashes offline — save to evidence, message state-mgr `[add-cred]`, return.

--- a/teammates/net-enum.md
+++ b/teammates/net-enum.md
@@ -7,7 +7,7 @@ you execute, report, and wait for the next assignment.
 
 > **HARD STOP — VULN CONFIRMED:** When you confirm an actionable condition
 > (null session with write access, default creds on a management interface,
-> unauthenticated RCE, writable share) — STOP. Do NOT exercise it.
+> unauthenticated RCE, writable share) — STOP. Do NOT action it.
 > 1. Message state-mgr: `[add-vuln]` with details
 > 2. Wait for `[vuln-written] id=<N>` confirmation
 > 3. Message lead with the finding + vuln ID
@@ -77,7 +77,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-pivot] from_ip=<ip> to_subnet=<cidr> pivot_type="<type>"
 [add-target] ip=<ip> hostname=<host> os="<os>"
 [update-target] ip=<ip> hostname=<host> notes="<notes>"
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -138,7 +138,7 @@ background jobs so you can receive messages.
 ## Scope Boundaries
 
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.
-- Do NOT exercise vulnerabilities — find and report. The lead routes technique execution.
+- Do NOT action vulnerabilities — find and report. The lead routes technique execution.
 - Do NOT interact with HTTP services (no curl/wget against web ports) — that's the web teammate.
 - Do NOT perform web app testing, AD enumeration, or privilege escalation.
 - Do NOT recover hashes offline — save to evidence, message state-mgr `[add-cred]`, report.

--- a/teammates/research.md
+++ b/teammates/research.md
@@ -103,7 +103,7 @@ WebSearch/WebFetch run from attackbox — they don't touch the target.
 - CVE: <if applicable>
 
 ### Exploitation
-- Method: <how exercised>
+- Method: <how actioned>
 - Impact: <root shell, file read, privesc>
 - PoC source: <URL or "custom">
 

--- a/teammates/state-mgr.md
+++ b/teammates/state-mgr.md
@@ -129,16 +129,16 @@ This is your primary value — LLM-level judgment that DB string matching cannot
 For every `[add-vuln]`:
 1. Call `get_vulns(target=<ip>)` — load all existing vulns for that target.
 2. Compare incoming title + type + details against each existing vuln.
-3. **Exercise outcome of existing vuln** (same endpoint, same technique, but
-   now reporting it was exercised successfully — e.g., "LFI UNC coercion →
+3. **Action outcome of existing vuln** (same endpoint, same technique, but
+   now reporting it was actioned successfully — e.g., "LFI UNC coercion →
    NTLMv2 capture" when "LFI in view parameter" already exists):
-   → `update_vuln(id=<existing>, status="exercised")`, merge details.
+   → `update_vuln(id=<existing>, status="actioned")`, merge details.
    This triggers automatic graph pruning — sibling `found` vulns from the
    same access are hidden from the flow graph. The dashboard renders the
-   exercised vuln as an action node (the vuln IS the technique). The
+   actioned vuln as an action node (the vuln IS the technique). The
    credential or access gained is the evidence — it gets its own
    `add_credential(via_vuln_id=N)` or `add_access()` record, not a new vuln. Respond `[vuln-merged]` to teammate with the existing ID
-   and pruning count. Do NOT create a new vuln row for the exercise step.
+   and pruning count. Do NOT create a new vuln row for the action step.
 4. **Same finding, different wording** (e.g., "LFI file read" vs "LFI via
    absolute path", "LDAP signing not enforced" vs "LDAP signing disabled"):
    → `update_vuln()` on existing record, merge details if incoming has more info.
@@ -152,7 +152,7 @@ For every `[add-vuln]`:
 
 **Key signal:** If the teammate includes `via_vuln_id=<N>` in an `[add-cred]`
 or the incoming vuln references the same technique as an existing finding,
-that's an exercise update, not a new finding.
+that's an action update, not a new finding.
 
 ### Credential Dedup
 
@@ -204,15 +204,15 @@ For every `[add-access]`:
 
 You own provenance links. Two mandatory checks on **every write**:
 
-### Auto-exercise vulns
+### Auto-action vulns
 
 When ANY write includes `via_vuln_id=<N>` (credential, access, or another vuln),
-that vuln produced a result — it was exercised. Immediately:
-1. Call `update_vuln(id=<N>, status="exercised")` if not already exercised
+that vuln produced a result — it was actioned. Immediately:
+1. Call `update_vuln(id=<N>, status="actioned")` if not already actioned
 2. Then check: does vuln N itself have provenance? (`via_access_id`,
    `via_credential_id`, or `via_vuln_id`)? If not, ask the sender:
    `[chain-gap] vuln id=<N> has no provenance — what access/cred/vuln led to it?`
-3. Continue recursively: if vuln N has `via_vuln_id=<M>`, mark M exercised too.
+3. Continue recursively: if vuln N has `via_vuln_id=<M>`, mark M actioned too.
    Trace the full chain back to the root.
 
 ### Chain completeness audit
@@ -245,7 +245,7 @@ Every `via_*` field creates an edge. You can set or fix them post-creation:
 |------|---------|-----------|
 | access.via_vuln_id | "exploited this vuln to get this access" | vuln → access |
 | access.via_credential_id | "used this cred to gain access" | cred → access |
-| access.via_access_id | "escalated from this access" | access → access (routed through exercised vuln if one exists) |
+| access.via_access_id | "escalated from this access" | access → access (routed through actioned vuln if one exists) |
 | vuln.via_access_id | "discovered this vuln during this access" | access → vuln |
 | vuln.via_credential_id | "found this vuln using this credential" | cred → vuln |
 | vuln.via_vuln_id | "this vuln chains from that vuln" (e.g., SSRF → RCE) | vuln → vuln |
@@ -297,17 +297,17 @@ Set `in_graph=0` to hide nodes that clutter the narrative:
 
 ## Graph Pruning
 
-The state server automatically manages the flow graph when vulns are exercised
+The state server automatically manages the flow graph when vulns are actioned
 or paths are abandoned. You do not need to manage `in_graph` manually.
 
-- **On exercise**: When you call `update_vuln(status="exercised")`, the
+- **On action**: When you call `update_vuln(status="actioned")`, the
   server sets `in_graph=0` on sibling `found` vulns from the same
   `via_access_id` + target. These were alternative findings — they clutter
   the graph once a path moves forward. The response includes
   `siblings_pruned` count when this happens.
 
 - **On abandonment**: When you call `update_vuln(status="blocked")` on a
-  previously exercised vuln, or `update_access(active=false)` to revoke
+  previously actioned vuln, or `update_access(active=false)` to revoke
   access, the server restores pruned siblings (`in_graph=1`) so alternative
   paths reappear. Response includes `siblings_restored` count.
 
@@ -317,7 +317,7 @@ or paths are abandoned. You do not need to manage `in_graph` manually.
 
 Include pruning info in your confirmations:
 ```
-[vuln-updated] id=N status=exercised (3 siblings pruned from graph)
+[vuln-updated] id=N status=actioned (3 siblings pruned from graph)
 [vuln-updated] id=N status=blocked (2 siblings restored to graph)
 ```
 
@@ -350,7 +350,7 @@ update_tunnel(id, status, notes)
 - `add_credential(secret_type=)` — valid: `password`, `ntlm_hash`, `net_ntlm`,
   `aes_key`, `kerberos_tgt`, `kerberos_tgs`, `dcc2`, `ssh_key`, `token`,
   `certificate`, `webapp_hash`, `dpapi`, `other`
-- `add_vuln(status=)` — valid: `found`, `exercised`, `blocked`
+- `add_vuln(status=)` — valid: `found`, `actioned`, `blocked`
 - `add_vuln(severity=)` — valid: `info`, `low`, `medium`, `high`, `critical`
 - `add_blocked(retry=)` — valid: `no`, `later`, `with_context`
 - `add_blocked(ip=)` — must match an existing target if provided

--- a/teammates/web-enum.md
+++ b/teammates/web-enum.md
@@ -7,7 +7,7 @@ tasks — the lead assigns work, you execute, report, and wait.
 
 > **HARD STOP — VULN CONFIRMED:** When you confirm a vulnerability (SQLi,
 > IDOR, LFI, SSRF, RCE, auth bypass, file upload, etc.) — STOP. Do NOT
-> exercise it, do NOT chain it, do NOT "just check" what's behind it.
+> action it, do NOT chain it, do NOT "just check" what's behind it.
 > 1. Message state-mgr: `[add-vuln]` with details
 > 2. Wait for `[vuln-written] id=<N>` confirmation
 > 3. Message lead with the finding + vuln ID
@@ -23,7 +23,7 @@ tasks — the lead assigns work, you execute, report, and wait.
 > tokens, keys) at ANY point — from config files, default creds, exposed
 > endpoints, or any other source — STOP what you are doing.
 >
-> **Technique = vuln.** If the credential came from exercising an endpoint
+> **Technique = vuln.** If the credential came from actioning an endpoint
 > (auth bypass → admin panel, exposed API returning secrets), send
 > `[add-vuln]` for the technique FIRST, then `[add-cred]` with
 > `via_vuln_id=<M>`. Only skip `via_vuln_id` for truly passive finds
@@ -76,7 +76,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-cred] username=<user> secret=<secret> secret_type=<type> source="<source>" via_access_id=<N>
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 

--- a/teammates/web-ops.md
+++ b/teammates/web-ops.md
@@ -41,7 +41,7 @@ multiple tasks — the lead assigns work, you execute, report, and wait.
 5. Message the lead with a structured summary.
 6. Mark the task complete. **Wait for next assignment. Never self-claim tasks.**
 
-**Exercise the assigned vulnerability using the loaded technique skill. Don't
+**Action the assigned vulnerability using the loaded technique skill. Don't
 discover new vulns — the lead routes discovery to web-enum.**
 
 ## Communication
@@ -70,7 +70,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-cred] username=<user> secret=<secret> secret_type=<type> source="<source>" via_access_id=<N> via_vuln_id=<M>
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_access_id=<M> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -146,7 +146,7 @@ background jobs so you can receive messages.
 
 ## Scope Boundaries
 
-- Exercise the assigned vulnerability — do NOT run content discovery (ffuf, vhost fuzzing). The lead routes discovery to web-enum.
+- Action the assigned vulnerability — do NOT run content discovery (ffuf, vhost fuzzing). The lead routes discovery to web-enum.
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.
 - Do NOT perform network scanning (nmap, masscan).
 - Do NOT perform AD enumeration or Kerberos attacks.

--- a/teammates/win-enum.md
+++ b/teammates/win-enum.md
@@ -6,7 +6,7 @@ network configuration. You persist across multiple tasks.
 
 > **HARD STOP — VULN CONFIRMED:** When you confirm a privesc vector
 > (unquoted service path, writable service binary, SeImpersonate with no
-> AV, missing patch for known CVE) — STOP. Do NOT exercise it.
+> AV, missing patch for known CVE) — STOP. Do NOT action it.
 > 1. Message state-mgr: `[add-vuln]` with details
 > 2. Wait for `[vuln-written] id=<N>` confirmation
 > 3. Message lead with the finding + vuln ID
@@ -72,7 +72,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_access_id=<M> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
 [add-pivot] from_ip=<ip> to_subnet=<cidr> pivot_type="<type>"
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -126,7 +126,7 @@ failure — do not reinvent it.
 
 ## Scope Boundaries
 
-- Do NOT exercise privesc vectors — see HARD STOP — VULN CONFIRMED above.
+- Do NOT action privesc vectors — see HARD STOP — VULN CONFIRMED above.
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.
 - Do NOT run Linux commands — Windows hosts only. Wrong OS → report, return.
 - Do NOT interact with web services, URLs, or HTTP endpoints — no curl, no browser, no downloading/decoding web content. If you find a URL, report it to the lead.

--- a/teammates/win-ops.md
+++ b/teammates/win-ops.md
@@ -59,7 +59,7 @@ All state writes go through state-mgr. Send structured messages:
 [add-access] ip=<ip> method=<method> user=<user> level=<level> via_credential_id=<N> via_access_id=<M> via_vuln_id=<V>
 [add-blocked] ip=<ip> technique="<name>" reason="<why>" retry=<no|later|with_context>
 [add-pivot] from_ip=<ip> to_subnet=<cidr> pivot_type="<type>"
-[update-vuln] id=<N> status=exercised details="<details>"
+[update-vuln] id=<N> status=actioned details="<details>"
 ```
 Batch multiple writes in one message when possible.
 
@@ -103,11 +103,11 @@ failure — do not reinvent it.
 
 ## Scope Boundaries
 
-- Exercise the assigned privesc vector using the loaded technique skill. Don't run
+- Action the assigned privesc vector using the loaded technique skill. Don't run
   full enumeration — the lead routes discovery to win-enum.
 - Do NOT call `search_skills()` or `list_skills()` — only `get_skill()`.
 - Do NOT run Linux commands — Windows hosts only. Wrong OS → report, return.
-- Do NOT exercise web services — report and return.
+- Do NOT action web services — report and return.
 - Do NOT perform network scanning or AD-specific enumeration (BloodHound, ADCS).
 - Do NOT recover hashes offline — save to evidence, message state-mgr `[add-cred]`, return.
 - **Outbound connectivity issues from target** (reverse shell never

--- a/tools/state-server/README.md
+++ b/tools/state-server/README.md
@@ -56,13 +56,13 @@ as a safety net but is not the primary dedup mechanism.
 The server automatically manages `in_graph` flags to keep the dashboard flow
 graph clean:
 
-- **On exercise**: `update_vuln(status="exercised")` sets `in_graph=0` on
+- **On action**: `update_vuln(status="actioned")` sets `in_graph=0` on
   sibling `found` vulns sharing the same `via_access_id` and target. Response
   includes `"siblings_pruned": N`.
 
 - **On abandonment**: `update_vuln(status="blocked")` or
   `update_access(active=false)` restores pruned siblings (`in_graph=1`) if no
-  other exercised vuln exists from the same access. Response includes
+  other actioned vuln exists from the same access. Response includes
   `"siblings_restored": N`.
 
 - **Manual override**: `update_vuln(id=N, in_graph=0|1)` to force
@@ -116,7 +116,7 @@ writer, contention is minimal.
 | `add_access` | `ip` (required), `access_type`, `username`, `privilege`, `method`, `session_ref`, `via_credential_id`, `via_access_id`, `via_vuln_id`, `technique_id`, `chain_order`, `discovered_by` | Record a new foothold on a target (chain provenance via credential, access, or vuln) |
 | `update_access` | `id` (required), `active`, `username`, `access_type`, `privilege`, `notes`, `via_credential_id`, `via_access_id`, `via_vuln_id`, `technique_id`, `in_graph`, `chain_order` | Update access record (e.g., revoke, fix provenance, reposition in graph). Restores pruned sibling vulns on revocation |
 | `add_vuln` | `title` (required), `ip` (required), `vuln_type`, `severity`, `status`, `details`, `evidence_path`, `via_access_id`, `via_credential_id`, `via_vuln_id`, `technique_id`, `chain_order`, `discovered_by` | Record a vulnerability (deduplicates on target+title) |
-| `update_vuln` | `id` (required), `status`, `severity`, `details`, `in_graph`, `via_access_id`, `via_credential_id`, `via_vuln_id`, `technique_id`, `chain_order` | Update vulnerability status (found/exercised/blocked). Auto-prunes sibling found vulns on exercise, restores on block |
+| `update_vuln` | `id` (required), `status`, `severity`, `details`, `in_graph`, `via_access_id`, `via_credential_id`, `via_vuln_id`, `technique_id`, `chain_order` | Update vulnerability status (found/actioned/blocked). Auto-prunes sibling found vulns on action, restores on block |
 | `add_pivot` | `source`, `destination` (required), `method`, `status` | Record a pivot path |
 | `update_pivot` | `id` (required), `status`, `notes` | Update pivot path status |
 | `add_blocked` | `technique`, `reason` (required), `ip`, `retry`, `notes` | Record a blocked/failed technique |
@@ -135,7 +135,7 @@ The database has 10 tables:
 | `credentials` | Username/secret pairs with type (password, ntlm_hash, net_ntlm, kerberos_tgs, dcc2, webapp_hash, dpapi, etc.) |
 | `credential_access` | Where each credential has been tested and whether it worked |
 | `access` | Active footholds — shells, sessions, tokens |
-| `vulns` | Confirmed vulnerabilities with severity and status (found/exercised/blocked) |
+| `vulns` | Confirmed vulnerabilities with severity and status (found/actioned/blocked) |
 | `pivot_map` | Directed edges showing what leads where |
 | `blocked` | Failed techniques with reasons and retry assessment |
 | `tunnels` | Active tunnels — type, pivot host, target subnet, endpoints, proxychains requirement |

--- a/tools/state-server/schema.py
+++ b/tools/state-server/schema.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-SCHEMA_VERSION = 21
+SCHEMA_VERSION = 22
 
 SCHEMA_SQL = """\
 PRAGMA journal_mode=WAL;
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS vulns (
     title         TEXT NOT NULL,
     vuln_type     TEXT NOT NULL DEFAULT '',
     status        TEXT NOT NULL DEFAULT 'found'
-                  CHECK (status IN ('found', 'exercised', 'blocked')),
+                  CHECK (status IN ('found', 'actioned', 'blocked')),
     severity      TEXT NOT NULL DEFAULT 'medium'
                   CHECK (severity IN ('info', 'low', 'medium', 'high', 'critical')),
     details       TEXT NOT NULL DEFAULT '',
@@ -137,7 +137,7 @@ CREATE TABLE IF NOT EXISTS pivot_map (
     destination   TEXT NOT NULL,
     method        TEXT NOT NULL DEFAULT '',
     status        TEXT NOT NULL DEFAULT 'identified'
-                  CHECK (status IN ('identified', 'exercised', 'blocked')),
+                  CHECK (status IN ('identified', 'actioned', 'blocked')),
     notes         TEXT NOT NULL DEFAULT '',
     discovered_by TEXT NOT NULL DEFAULT '',
     created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
@@ -248,7 +248,7 @@ def _migrate_v7_to_v8(conn: sqlite3.Connection) -> None:
             title         TEXT NOT NULL,
             vuln_type     TEXT NOT NULL DEFAULT '',
             status        TEXT NOT NULL DEFAULT 'found'
-                          CHECK (status IN ('found', 'exercised', 'blocked')),
+                          CHECK (status IN ('found', 'actioned', 'blocked')),
             severity      TEXT NOT NULL DEFAULT 'medium'
                           CHECK (severity IN ('info', 'low', 'medium', 'high', 'critical')),
             details       TEXT NOT NULL DEFAULT '',
@@ -317,9 +317,9 @@ def _migrate_v5_to_v6(conn: sqlite3.Connection) -> None:
     """Migrate schema from v5 to v6: change vuln status lifecycle.
 
     Old statuses: found, active, done
-    New statuses: found, exploited, blocked
+    New statuses: found, actioned, blocked
 
-    Mapping: active -> exploited, done -> exploited, found stays.
+    Mapping: active -> actioned, done -> actioned, found stays.
     Recreates vulns table with new CHECK constraint (SQLite can't ALTER CHECK).
     """
     conn.executescript("""
@@ -331,7 +331,7 @@ def _migrate_v5_to_v6(conn: sqlite3.Connection) -> None:
             title         TEXT NOT NULL,
             vuln_type     TEXT NOT NULL DEFAULT '',
             status        TEXT NOT NULL DEFAULT 'found'
-                          CHECK (status IN ('found', 'exercised', 'blocked')),
+                          CHECK (status IN ('found', 'actioned', 'blocked')),
             severity      TEXT NOT NULL DEFAULT 'medium'
                           CHECK (severity IN ('info', 'low', 'medium', 'high', 'critical')),
             endpoint      TEXT NOT NULL DEFAULT '',
@@ -348,8 +348,8 @@ def _migrate_v5_to_v6(conn: sqlite3.Connection) -> None:
                           discovered_by, created_at, updated_at)
             SELECT id, target_id, title, vuln_type,
                    CASE status
-                       WHEN 'active' THEN 'exercised'
-                       WHEN 'done' THEN 'exercised'
+                       WHEN 'active' THEN 'actioned'
+                       WHEN 'done' THEN 'actioned'
                        ELSE status
                    END,
                    severity, endpoint, details, evidence_path, via_access_id,
@@ -386,6 +386,16 @@ def _migrate_v3_to_v4(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _migrate_v21_to_v22(conn: sqlite3.Connection) -> None:
+    """Migrate schema from v21 to v22: rename 'exercised' status to 'actioned'.
+
+    Updates vulns.status and pivot_map.status enum values.
+    """
+    conn.execute("UPDATE vulns SET status = 'actioned' WHERE status = 'exercised'")
+    conn.execute("UPDATE pivot_map SET status = 'actioned' WHERE status = 'exercised'")
+    conn.commit()
+
+
 def _migrate_v20_to_v21(conn: sqlite3.Connection) -> None:
     """Migrate schema from v20 to v21: add via_vuln_id to vulns table."""
     cols = [r[1] for r in conn.execute("PRAGMA table_info(vulns)").fetchall()]
@@ -398,7 +408,7 @@ def _migrate_v20_to_v21(conn: sqlite3.Connection) -> None:
 
 
 def _migrate_v19_to_v20(conn: sqlite3.Connection) -> None:
-    """Migrate schema from v19 to v20: rename 'exploited' status to 'exercised'.
+    """Migrate schema from v19 to v20: rename 'exploited' status to 'actioned'.
 
     Updates vulns.status and pivot_map.status enum values. SQLite can't ALTER
     CHECK constraints, so we update the data first (old CHECK allows both) and
@@ -406,8 +416,8 @@ def _migrate_v19_to_v20(conn: sqlite3.Connection) -> None:
     constraint on fresh DBs. For existing DBs, the CHECK constraint from the
     table creation is already in place — we just need to update the data.
     """
-    conn.execute("UPDATE vulns SET status = 'exercised' WHERE status = 'exploited'")
-    conn.execute("UPDATE pivot_map SET status = 'exercised' WHERE status = 'exploited'")
+    conn.execute("UPDATE vulns SET status = 'actioned' WHERE status = 'exploited'")
+    conn.execute("UPDATE pivot_map SET status = 'actioned' WHERE status = 'exploited'")
     conn.commit()
 
 
@@ -657,6 +667,8 @@ def init_db(db_path: str | Path) -> sqlite3.Connection:
             _migrate_v19_to_v20(conn)
         if current_version <= 20:
             _migrate_v20_to_v21(conn)
+        if current_version <= 21:
+            _migrate_v21_to_v22(conn)
 
     conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     conn.commit()

--- a/tools/state-server/server.py
+++ b/tools/state-server/server.py
@@ -63,9 +63,9 @@ _VALID_ENUMS: dict[str, tuple[str, ...]] = {
         "domain_admin",
         "other",
     ),
-    "vuln_status": ("found", "exercised", "blocked"),
+    "vuln_status": ("found", "actioned", "blocked"),
     "severity": ("info", "low", "medium", "high", "critical"),
-    "pivot_status": ("identified", "exercised", "blocked"),
+    "pivot_status": ("identified", "actioned", "blocked"),
     "retry": ("no", "later", "with_context"),
     "tunnel_status": ("active", "down", "closed"),
 }
@@ -512,7 +512,7 @@ def create_server() -> FastMCP:
         """Get vulnerabilities.
 
         Args:
-            status: Filter by status (found/exercised/blocked, empty = all).
+            status: Filter by status (found/actioned/blocked, empty = all).
             target: Filter by target host (empty = all).
         """
         with _get_db() as conn:
@@ -539,7 +539,7 @@ def create_server() -> FastMCP:
         """Get pivot map edges.
 
         Args:
-            status: Filter by status (identified/exercised/blocked, empty = all).
+            status: Filter by status (identified/actioned/blocked, empty = all).
         """
         with _get_db() as conn:
             if status:
@@ -704,7 +704,7 @@ def create_server() -> FastMCP:
                         ),
                     }
                 )
-                # Follow: access gained by exercising this vuln
+                # Follow: access gained by actioning this vuln
                 for a in accesses.values():
                     if a.get("via_vuln_id") == vid:
                         add_access(a["id"], depth + 1, "vuln", vid)
@@ -1342,7 +1342,7 @@ def create_server() -> FastMCP:
                               (for chain provenance). None = no credential used.
             via_access_id: Access ID this was escalated from (for privesc
                           chains on the same host). None = initial access.
-            via_vuln_id: Vuln ID that was exercised to gain this access
+            via_vuln_id: Vuln ID that was actioned to gain this access
                         (for chain provenance). None = no specific vuln.
             technique_id: ATT&CK technique ID (e.g., "T1021.006" for WinRM).
                          Empty = fill in later during reporting.
@@ -1420,7 +1420,7 @@ def create_server() -> FastMCP:
         """Update access record (e.g., revoke, fix provenance, toggle graph).
 
         When access is revoked (active=false), sibling vulns that were pruned
-        from the flow graph when this access's exercised vulns succeeded are
+        from the flow graph when this access's actioned vulns succeeded are
         restored — making alternative paths visible again.
 
         Args:
@@ -1487,7 +1487,7 @@ def create_server() -> FastMCP:
             _emit_event(conn, "access_update", id, f"access #{id} updated")
 
             # When access is revoked, restore sibling vulns that were pruned
-            # when exercised vulns from this access succeeded
+            # when actioned vulns from this access succeeded
             restored = 0
             if active is False:
                 restored = _restore_vulns_for_access(conn, id)
@@ -1524,7 +1524,7 @@ def create_server() -> FastMCP:
             title: Short vulnerability title (e.g., "SQLi in /search parameter").
             ip: Target IP (required — must match an existing target).
             vuln_type: Vulnerability class (e.g., "sqli", "xss", "rce").
-            status: Status: found, exercised, blocked.
+            status: Status: found, actioned, blocked.
             severity: Severity: info, low, medium, high, critical.
             details: Technical details.
             evidence_path: Path to evidence file in engagement/evidence/.
@@ -1626,16 +1626,16 @@ def create_server() -> FastMCP:
                 indent=2,
             )
 
-    def _prune_sibling_vulns(conn: sqlite3.Connection, exercised_vuln_id: int) -> int:
+    def _prune_sibling_vulns(conn: sqlite3.Connection, actioned_vuln_id: int) -> int:
         """Set in_graph=0 on sibling 'found' vulns sharing the same via_access_id.
 
-        When a vuln is exercised, the alternative findings from the same access
+        When a vuln is actioned, the alternative findings from the same access
         point are noise in the flow graph. Prune them so only the actioned path
         is visible. Returns count of pruned vulns.
         """
         row = conn.execute(
             "SELECT via_access_id, target_id FROM vulns WHERE id = ?",
-            (exercised_vuln_id,),
+            (actioned_vuln_id,),
         ).fetchone()
         if not row or not row["via_access_id"]:
             return 0
@@ -1643,23 +1643,23 @@ def create_server() -> FastMCP:
             f"UPDATE vulns SET in_graph = 0, updated_at = {_now_sql()} "
             "WHERE via_access_id = ? AND target_id = ? AND id != ? "
             "AND status = 'found' AND in_graph = 1",
-            (row["via_access_id"], row["target_id"], exercised_vuln_id),
+            (row["via_access_id"], row["target_id"], actioned_vuln_id),
         )
         count = cursor.rowcount
         if count:
             _emit_event(
                 conn,
                 "vuln_prune",
-                exercised_vuln_id,
-                f"Pruned {count} sibling vuln(s) (vuln #{exercised_vuln_id} exercised)",
+                actioned_vuln_id,
+                f"Pruned {count} sibling vuln(s) (vuln #{actioned_vuln_id} actioned)",
             )
         return count
 
     def _restore_sibling_vulns(conn: sqlite3.Connection, vuln_id: int) -> int:
-        """Restore in_graph=1 on sibling vulns when an exercised path fails.
+        """Restore in_graph=1 on sibling vulns when an actioned path fails.
 
         Called when a vuln is blocked or its parent access is revoked. Only
-        restores if no other exercised vuln exists from the same access point.
+        restores if no other actioned vuln exists from the same access point.
         Returns count of restored vulns.
         """
         row = conn.execute(
@@ -1668,10 +1668,10 @@ def create_server() -> FastMCP:
         ).fetchone()
         if not row or not row["via_access_id"]:
             return 0
-        # Only restore if no other exercised vuln exists from same access
+        # Only restore if no other actioned vuln exists from same access
         other = conn.execute(
             "SELECT id FROM vulns WHERE via_access_id = ? AND target_id = ? "
-            "AND id != ? AND status = 'exercised'",
+            "AND id != ? AND status = 'actioned'",
             (row["via_access_id"], row["target_id"], vuln_id),
         ).fetchone()
         if other:
@@ -1693,9 +1693,9 @@ def create_server() -> FastMCP:
         return count
 
     def _restore_vulns_for_access(conn: sqlite3.Connection, access_id: int) -> int:
-        """Restore sibling vulns for all exercised vulns under a revoked access."""
+        """Restore sibling vulns for all actioned vulns under a revoked access."""
         rows = conn.execute(
-            "SELECT id FROM vulns WHERE via_access_id = ? AND status = 'exercised'",
+            "SELECT id FROM vulns WHERE via_access_id = ? AND status = 'actioned'",
             (access_id,),
         ).fetchall()
         total = 0
@@ -1718,14 +1718,14 @@ def create_server() -> FastMCP:
     ) -> str:
         """Update vulnerability (e.g., change status, fix provenance, toggle graph).
 
-        When status changes to 'exercised', sibling 'found' vulns from the
+        When status changes to 'actioned', sibling 'found' vulns from the
         same access point are automatically hidden from the flow graph
         (in_graph=0). When status changes to 'blocked', hidden siblings are
-        restored if no other exercised path exists.
+        restored if no other actioned path exists.
 
         Args:
             id: Vulnerability ID.
-            status: Updated status (found/exercised/blocked).
+            status: Updated status (found/actioned/blocked).
             severity: Updated severity.
             details: Updated details.
             in_graph: Override graph visibility (1=show, 0=hide). Normally
@@ -1793,7 +1793,7 @@ def create_server() -> FastMCP:
             # Auto-prune/restore sibling vulns based on status transition
             pruned = 0
             restored = 0
-            if status == "exercised":
+            if status == "actioned":
                 pruned = _prune_sibling_vulns(conn, id)
             elif status == "blocked":
                 restored = _restore_sibling_vulns(conn, id)
@@ -1821,7 +1821,7 @@ def create_server() -> FastMCP:
             source: Source (e.g., "SQLi on 10.10.10.5:/search").
             destination: Destination (e.g., "DB creds for 10.10.10.1:mssql").
             method: How the pivot works.
-            status: Status: identified, exercised, blocked.
+            status: Status: identified, actioned, blocked.
             discovered_by: Skill that identified this path.
             notes: Additional notes.
         """
@@ -1864,7 +1864,7 @@ def create_server() -> FastMCP:
 
         Args:
             id: Pivot ID.
-            status: Updated status (identified/exercised/blocked).
+            status: Updated status (identified/actioned/blocked).
             notes: Updated notes.
         """
         if status:

--- a/tools/state-server/tests/test_state_server.py
+++ b/tools/state-server/tests/test_state_server.py
@@ -214,7 +214,7 @@ class TestAccessCrud:
     def test_access_via_vuln_id(self, srv):
         call(srv, "add_target", ip="10.10.10.10")
         vuln = call_json(srv, "add_vuln", title="RCE", ip="10.10.10.10",
-                         severity="critical", status="exercised")
+                         severity="critical", status="actioned")
         access = call_json(srv, "add_access", ip="10.10.10.10",
                            username="www-data", via_vuln_id=vuln["vuln_id"])
         all_access = json.loads(call(srv, "get_access"))
@@ -249,8 +249,8 @@ class TestAccessCrud:
                         severity="high", via_access_id=aid)
         v2 = call_json(srv, "add_vuln", title="LFI", ip="10.10.10.12",
                         severity="medium", via_access_id=aid)
-        # Exploit one — should prune sibling
-        call(srv, "update_vuln", id=v1["vuln_id"], status="exercised")
+        # Action one — should prune sibling
+        call(srv, "update_vuln", id=v1["vuln_id"], status="actioned")
         # Revoke access — should restore pruned sibling
         call(srv, "update_access", id=aid, active=False)
         vulns = json.loads(call(srv, "get_vulns", target="10.10.10.12"))
@@ -276,7 +276,7 @@ class TestVulnCrud:
         assert d2.get("status") == "duplicate_skipped"
         assert d2["vuln_id"] == d1["vuln_id"]
 
-    def test_exploit_prunes_siblings(self, srv):
+    def test_action_prunes_siblings(self, srv):
         call(srv, "add_target", ip="10.10.10.15")
         a = call_json(srv, "add_access", ip="10.10.10.15", username="user1")
         aid = a["access_id"]
@@ -284,7 +284,7 @@ class TestVulnCrud:
                         severity="high", via_access_id=aid)
         v2 = call_json(srv, "add_vuln", title="LFI", ip="10.10.10.15",
                         severity="medium", via_access_id=aid)
-        result = call_json(srv, "update_vuln", id=v1["vuln_id"], status="exercised")
+        result = call_json(srv, "update_vuln", id=v1["vuln_id"], status="actioned")
         assert result.get("siblings_pruned", 0) >= 1
         vulns = json.loads(call(srv, "get_vulns", target="10.10.10.15"))
         lfi = [v for v in vulns if v["id"] == v2["vuln_id"]][0]
@@ -298,8 +298,8 @@ class TestVulnCrud:
                         severity="high", via_access_id=aid)
         v2 = call_json(srv, "add_vuln", title="LFI", ip="10.10.10.16",
                         severity="medium", via_access_id=aid)
-        # Exploit then block
-        call(srv, "update_vuln", id=v1["vuln_id"], status="exercised")
+        # Action then block
+        call(srv, "update_vuln", id=v1["vuln_id"], status="actioned")
         call(srv, "update_vuln", id=v1["vuln_id"], status="blocked")
         vulns = json.loads(call(srv, "get_vulns", target="10.10.10.16"))
         lfi = [v for v in vulns if v["id"] == v2["vuln_id"]][0]
@@ -335,7 +335,7 @@ class TestChainBfs:
         """access.via_vuln_id should create a vuln→access edge in BFS."""
         call(srv, "add_target", ip="10.10.10.21")
         vuln = call_json(srv, "add_vuln", title="RCE", ip="10.10.10.21",
-                         severity="critical", status="exercised")
+                         severity="critical", status="actioned")
         call(srv, "add_access", ip="10.10.10.21", username="www-data",
              via_vuln_id=vuln["vuln_id"])
         chain = json.loads(call(srv, "get_chain"))


### PR DESCRIPTION
## Summary
- Rename `exercised` → `actioned` across state DB, dashboard, templates, and docs (terminology alignment)
- config.sh Sliver improvements: no longer tries to manage the Sliver server directly (start/stop/unpack). Checks for operator config and offers interactive setup — generate from local daemon, provide path from remote C2, or skip
- Fixes config.sh silently exiting on `sliver-server unpack` failure
- Step-by-step Sliver install docs for local and remote deployments
- Pre-registers sliver-server MCP in `.mcp.json` and `.claude/settings.json`

## Test plan
- [x] Verify `actioned` replaces `exercised` in state-server schema, dashboard, and all teammate templates
- [x] `./config.sh` → select sliver with no config → interactive prompt works (generate / provide path / cancel)
- [x] `./config.sh` → select sliver with existing `engagement/sliver.cfg` → detects and uses it
- [x] `./config.sh` → select shell-server → sliver path skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)